### PR TITLE
Implement holiday rates and refactor services

### DIFF
--- a/pricing-service/src/main/java/cl/kartingrm/pricing_service/model/TariffConfig.java
+++ b/pricing-service/src/main/java/cl/kartingrm/pricing_service/model/TariffConfig.java
@@ -3,19 +3,28 @@ package cl.kartingrm.pricing_service.model;
 import jakarta.persistence.*;
 import lombok.*;
 
+
 @Entity
-@Table(uniqueConstraints=@UniqueConstraint(columnNames="laps"))
+@Table(
+        name = "tariff_config",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"rate_type", "laps"})
+)
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-
-
 public class TariffConfig {
+
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    private int laps;
+
+    /** WEEKDAY / WEEKEND / HOLIDAY */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "rate_type", length = 10, nullable = false)
+    private RateType rateType;
+
+    private int laps;      // == minutes (simplificación)
     private int minutes;
-    private int basePrice;
+    private int basePrice; // CLP enteros
 }

--- a/pricing-service/src/main/java/cl/kartingrm/pricing_service/repository/TariffConfigRepository.java
+++ b/pricing-service/src/main/java/cl/kartingrm/pricing_service/repository/TariffConfigRepository.java
@@ -1,6 +1,7 @@
 package cl.kartingrm.pricing_service.repository;
 
 
+import cl.kartingrm.pricing_service.model.RateType;
 import cl.kartingrm.pricing_service.model.TariffConfig;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -8,5 +9,5 @@ import java.util.Optional;
 
 public interface TariffConfigRepository
         extends JpaRepository<TariffConfig,Long> {
-    Optional<TariffConfig> findByLaps(int laps);
+    Optional<TariffConfig> findByRateTypeAndLaps(RateType rateType, int laps);
 }

--- a/pricing-service/src/main/java/cl/kartingrm/pricing_service/service/HolidayService.java
+++ b/pricing-service/src/main/java/cl/kartingrm/pricing_service/service/HolidayService.java
@@ -3,8 +3,25 @@ package cl.kartingrm.pricing_service.service;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.time.MonthDay;
+import java.util.Set;
 
+/**
+ * Servicio sencillo: festivos fijos + fines de semana largo.
+ * En producción se reemplazaría por API oficial o tabla en BD.
+ */
 @Service
 public class HolidayService {
-    public boolean isHoliday(LocalDate d){ return false; }
+
+    private static final Set<MonthDay> FIXED_HOLIDAYS = Set.of(
+            MonthDay.of(1, 1),     // Año Nuevo
+            MonthDay.of(5, 1),     // Trabajador
+            MonthDay.of(9, 18),    // Chile – Fiestas Patrias
+            MonthDay.of(9, 19),
+            MonthDay.of(12, 25)    // Navidad
+    );
+
+    public boolean isHoliday(LocalDate date) {
+        return FIXED_HOLIDAYS.contains(MonthDay.from(date));
+    }
 }

--- a/pricing-service/src/main/java/cl/kartingrm/pricing_service/service/PricingService.java
+++ b/pricing-service/src/main/java/cl/kartingrm/pricing_service/service/PricingService.java
@@ -3,7 +3,7 @@ package cl.kartingrm.pricing_service.service;
 
 import cl.kartingrm.pricing_service.dto.*;
 import cl.kartingrm.pricing_service.model.TariffConfig;
-import cl.kartingrm.pricing_service.repository.TariffConfigRepository;
+import cl.kartingrm.pricing_service.service.TariffService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -11,13 +11,12 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class PricingService {
 
-    private final TariffConfigRepository tariffs;
+    private final TariffService tariffService;
     private final DiscountService disc;
 
     public PricingResponse calculate(PricingRequest dto) {
 
-        TariffConfig cfg = tariffs.findByLaps(dto.laps())
-                .orElseThrow(() -> new IllegalArgumentException("Tarifa no encontrada"));
+        TariffConfig cfg = tariffService.forDate(dto.sessionDate(), dto.laps());
 
         double base = cfg.getBasePrice();
         double groupPct = disc.groupDiscount(dto.participants());

--- a/pricing-service/src/main/java/cl/kartingrm/pricing_service/service/TariffService.java
+++ b/pricing-service/src/main/java/cl/kartingrm/pricing_service/service/TariffService.java
@@ -1,20 +1,27 @@
 // src/main/java/cl/kartingrm/pricing_service/service/TariffService.java
 package cl.kartingrm.pricing_service.service;
 
+import cl.kartingrm.pricing_service.model.RateType;
 import cl.kartingrm.pricing_service.model.TariffConfig;
 import cl.kartingrm.pricing_service.repository.TariffConfigRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-@Service
-@RequiredArgsConstructor
-public class TariffService {
-    private final TariffConfigRepository repo;   // PK de tipo Long
+import java.time.LocalDate;
 
-    // Buscar tarifa por número de vueltas (laps), en lugar de usar RateType
-    public TariffConfig forLaps(int laps) {
-        return repo.findByLaps(laps)
-                .orElseThrow(() ->
-                        new IllegalArgumentException("Tarifa no hallada para " + laps + " vueltas"));
+@Service @RequiredArgsConstructor
+public class TariffService {
+    private final TariffConfigRepository repo;
+    private final HolidayService holidays;
+
+    public TariffConfig forDate(LocalDate date, int laps) {
+        RateType type;
+        if (holidays.isHoliday(date)) type = RateType.HOLIDAY;
+        else if (date.getDayOfWeek().getValue() >= 6) type = RateType.WEEKEND;
+        else type = RateType.WEEKDAY;
+
+        return repo.findByRateTypeAndLaps(type, laps)
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "Tarifa no hallada para " + type + ", " + laps + " laps"));
     }
 }

--- a/pricing-service/src/main/resources/data.sql
+++ b/pricing-service/src/main/resources/data.sql
@@ -1,10 +1,13 @@
--- src/main/resources/data.sql
-
--- 1) Limpio la tabla antes de reinsertar
-TRUNCATE TABLE tariff_config;
-
--- 2) Inserto sólo los 3 registros base
-INSERT INTO tariff_config (laps, minutes, base_price) VALUES
-(10,10,15000),
-(15,15,20000),
-(20,20,25000);
+-- Inserción idempotente: se actualiza base_price si ya existe
+INSERT INTO tariff_config(rate_type,laps,minutes,base_price)
+VALUES
+  ('WEEKDAY',10,10,15000),
+  ('WEEKDAY',15,15,20000),
+  ('WEEKDAY',20,20,25000),
+  ('WEEKEND',10,10,17000),
+  ('WEEKEND',15,15,23000),
+  ('WEEKEND',20,20,28000),
+  ('HOLIDAY',10,10,19000),
+  ('HOLIDAY',15,15,26000),
+  ('HOLIDAY',20,20,31000)
+ON DUPLICATE KEY UPDATE base_price = VALUES(base_price);

--- a/pricing-service/src/main/resources/schema.sql
+++ b/pricing-service/src/main/resources/schema.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS tariff_config(
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    rate_type VARCHAR(10) NOT NULL,
+    laps INT NOT NULL,
+    minutes INT NOT NULL,
+    base_price INT NOT NULL,
+    UNIQUE KEY uq_rate_laps(rate_type,laps)
+) ENGINE=InnoDB;

--- a/pricing-service/src/test/java/cl/kartingrm/pricing_service/HolidayServiceTest.java
+++ b/pricing-service/src/test/java/cl/kartingrm/pricing_service/HolidayServiceTest.java
@@ -1,0 +1,19 @@
+package cl.kartingrm.pricing_service;
+
+import cl.kartingrm.pricing_service.service.HolidayService;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HolidayServiceTest {
+    private final HolidayService svc = new HolidayService();
+
+    @Test
+    void fixedHolidays() {
+        assertThat(svc.isHoliday(LocalDate.of(2025, 9, 18))).isTrue();
+        assertThat(svc.isHoliday(LocalDate.of(2025, 9, 19))).isTrue();
+        assertThat(svc.isHoliday(LocalDate.of(2025, 9, 17))).isFalse();
+    }
+}

--- a/pricing-service/src/test/java/cl/kartingrm/pricing_service/TariffServiceTest.java
+++ b/pricing-service/src/test/java/cl/kartingrm/pricing_service/TariffServiceTest.java
@@ -1,0 +1,25 @@
+package cl.kartingrm.pricing_service;
+
+import cl.kartingrm.pricing_service.model.RateType;
+import cl.kartingrm.pricing_service.service.TariffService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class TariffServiceTest {
+    @Autowired TariffService tariff;
+
+    @Test
+    void weekendAndHolidayDetection() {
+        var weekend = tariff.forDate(LocalDate.of(2025,6,7), 10);   // sábado
+        assertThat(weekend.getRateType()).isEqualTo(RateType.WEEKEND);
+
+        var holiday = tariff.forDate(LocalDate.of(2025,9,18), 10);
+        assertThat(holiday.getRateType()).isEqualTo(RateType.HOLIDAY);
+    }
+}

--- a/reservation-service/src/main/java/cl/kartingrm/reservation_service/service/ReservationService.java
+++ b/reservation-service/src/main/java/cl/kartingrm/reservation_service/service/ReservationService.java
@@ -10,6 +10,8 @@ import cl.kartingrm.reservation_service.repository.ReservationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
 
 import java.time.LocalDate;
@@ -25,28 +27,45 @@ public class ReservationService {
     private String pricingUrl;
 
     public ReservationResponse create(CreateReservationRequest req) {
+        // 1) Consultar microservicio de precios FUERA de transacción
+        PricingResponse p = callPricing(req);
 
-        PricingRequest pricingReq = new PricingRequest(
-                req.laps(), req.participants(),
-                req.clientVisits(), req.birthdayCount(),
-                LocalDate.now());
+        // 2) Persistir en BD (transacción ACID corta)
+        Reservation saved = saveReservation(req, p);
+        return new ReservationResponse(saved.getId(), saved.getFinalPrice(), saved.getStatus());
+    }
 
-        PricingResponse p = rest.postForObject(
-                pricingUrl + "/api/pricing/calculate",
-                pricingReq, PricingResponse.class);
+    private PricingResponse callPricing(CreateReservationRequest req) {
+        try {
+            PricingRequest pricingReq = new PricingRequest(
+                    req.laps(), req.participants(),
+                    req.clientVisits(), req.birthdayCount(),
+                    LocalDate.now());
 
+            return rest.postForObject(
+                    pricingUrl + "/api/pricing/calculate",
+                    pricingReq, PricingResponse.class);
+        } catch (org.springframework.web.client.RestClientException ex) {
+            throw new IllegalStateException("No se pudo obtener precio del servicio externo", ex);
+        }
+    }
+
+    /**
+     * Transacción corta — solo inserción en una tabla local;
+     * admite REQUIRES_NEW para no propagar rollback a llamada externa ya realizada.
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    protected Reservation saveReservation(CreateReservationRequest req, PricingResponse p) {
         Reservation r = Reservation.builder()
                 .laps(req.laps())
                 .participants(req.participants())
                 .clientEmail(req.clientEmail())
-                .basePrice((int)(p.baseUnit() * req.participants()))
+                .basePrice((int) (p.baseUnit() * req.participants()))
                 .discountPercent((int) p.totalDiscountPct())
-                .finalPrice(p.finalPrice())         // el servicio ya devuelve total
+                .finalPrice(p.finalPrice())
                 .status("PENDING")
                 .build();
-
-        repo.save(r);
-        return new ReservationResponse(r.getId(), r.getFinalPrice(), r.getStatus());
+        return repo.save(r);
     }
 }
 

--- a/reservation-service/src/test/java/cl/kartingrm/reservation_service/ReservationServiceTest.java
+++ b/reservation-service/src/test/java/cl/kartingrm/reservation_service/ReservationServiceTest.java
@@ -1,0 +1,46 @@
+package cl.kartingrm.reservation_service;
+
+import cl.kartingrm.pricingclient.PricingResponse;
+import cl.kartingrm.reservation_service.controller.ReservationController;
+import cl.kartingrm.reservation_service.model.Reservation;
+import cl.kartingrm.reservation_service.repository.ReservationRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.client.RestTemplate;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(controllers = ReservationController.class)
+class ReservationServiceTest {
+
+    @Autowired MockMvc mvc;
+    @MockBean RestTemplate rest;
+    @MockBean ReservationRepository repo;
+
+    @Test
+    void reservationCreated_ok() throws Exception {
+        // 1) stub pricing response
+        PricingResponse price = new PricingResponse(20000,10,10,0,15,70200,12.25);
+        given(rest.postForObject(anyString(), any(), eq(PricingResponse.class))).willReturn(price);
+        given(repo.save(any())).willAnswer(i -> { Reservation r = i.getArgument(0); r.setId(1L); return r;});
+
+        mvc.perform(post("/api/reservations")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{" +
+                        "\"laps\":15,\"participants\":4,\"clientEmail\":\"a@b.com\",\"clientVisits\":3,\"weekend\":false,\"holiday\":false,\"birthdayCount\":0}"))
+           .andExpect(status().isOk())
+           .andExpect(jsonPath("$.id").value(1))
+           .andExpect(jsonPath("$.finalPrice").value(70200));
+
+        // 2) verifica SAVE ejecutado dentro de transacción
+        then(repo).should().save(any());
+    }
+}


### PR DESCRIPTION
## Summary
- support holiday/weekend rates with `RateType`
- add `HolidayService` and enhance `TariffService`
- route pricing logic through `TariffService`
- seed tariff table idempotently with `schema.sql`
- refactor `ReservationService` with transactional save and external pricing call
- add Spring tests for new services

## Testing
- `./mvnw -q test` in `pricing-service` *(fails: Non-resolvable parent POM)*
- `./mvnw -q test` in `reservation-service` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6840e7cce9b4832ca1337327b9a11a51