### PR TITLE
Add pricing tests and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,48 @@ KartingRM es un sistema modular de microservicios para la gestión de reservas e
 * **Calcular Precio**
   `GET /api/pricing?trackId=2&duration=30`
 
+## 🚦 Cómo levantar y probar los servicios
+
+1. **Crear bases de datos MySQL** (solo la primera vez):
+
+   ```sql
+   CREATE DATABASE IF NOT EXISTS pricingdb;
+   CREATE DATABASE IF NOT EXISTS reservationdb;
+   ```
+
+2. **Propiedades relevantes** (`application.properties`):
+
+   * pricing-service
+
+     ```properties
+     spring.datasource.url=jdbc:mysql://localhost:3306/pricingdb?createDatabaseIfNotExist=true&serverTimezone=UTC
+     spring.datasource.username=root
+     spring.datasource.password=password
+     ```
+
+   * reservation-service
+
+     ```properties
+     spring.datasource.url=jdbc:mysql://localhost:3306/reservationdb?createDatabaseIfNotExist=true&serverTimezone=UTC
+     spring.datasource.username=root
+     spring.datasource.password=password
+     pricing.service.url=http://localhost:8081
+     ```
+
+3. **Ejecutar pruebas**
+
+   ```bash
+   cd pricing-service && mvn test
+   cd ../reservation-service && mvn test
+   ```
+
+4. **Levantar cada servicio**
+
+   ```bash
+   cd pricing-service && mvn spring-boot:run
+   cd ../reservation-service && mvn spring-boot:run
+   ```
+
 ## 🔧 Pruebas
 
 * **Backend**:

--- a/pricing-service/src/test/java/cl/kartingrm/pricing_service/DiscountServiceTest.java
+++ b/pricing-service/src/test/java/cl/kartingrm/pricing_service/DiscountServiceTest.java
@@ -1,0 +1,40 @@
+package cl.kartingrm.pricing_service;
+
+import cl.kartingrm.pricing_service.service.DiscountService;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DiscountServiceTest {
+
+    private final DiscountService service = new DiscountService();
+
+    @Test
+    void groupDiscountCases() {
+        assertThat(service.groupDiscount(2)).isEqualTo(0);
+        assertThat(service.groupDiscount(4)).isEqualTo(10);
+        assertThat(service.groupDiscount(7)).isEqualTo(20);
+        assertThat(service.groupDiscount(12)).isEqualTo(30);
+    }
+
+    @Test
+    void frequentDiscountCases() {
+        assertThat(service.frequentDiscount(0)).isEqualTo(0);
+        assertThat(service.frequentDiscount(2)).isEqualTo(10);
+        assertThat(service.frequentDiscount(5)).isEqualTo(20);
+        assertThat(service.frequentDiscount(7)).isEqualTo(30);
+    }
+
+    @Test
+    void birthdayWinnersLogic() {
+        assertThat(service.birthdayWinners(2,1)).isEqualTo(0);
+        assertThat(service.birthdayWinners(4,2)).isEqualTo(1);
+        assertThat(service.birthdayWinners(8,3)).isEqualTo(2);
+    }
+
+    @Test
+    void birthdayDiscountEquivalent() {
+        assertThat(service.birthdayDiscount(5,2)).isEqualTo(20.0);
+        assertThat(service.birthdayDiscount(3,1)).isEqualTo(16.666666666666668);
+    }
+}

--- a/pricing-service/src/test/java/cl/kartingrm/pricing_service/PricingServiceTest.java
+++ b/pricing-service/src/test/java/cl/kartingrm/pricing_service/PricingServiceTest.java
@@ -1,0 +1,82 @@
+package cl.kartingrm.pricing_service;
+
+import cl.kartingrm.pricing_service.dto.PricingRequest;
+import cl.kartingrm.pricing_service.dto.PricingResponse;
+import cl.kartingrm.pricing_service.service.PricingService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class PricingServiceTest {
+
+    @Autowired
+    PricingService service;
+
+    @Test
+    void weekdayCalculation_withDiscounts() {
+        PricingRequest req = new PricingRequest(
+                10, // laps
+                3,  // participants
+                2,  // client visits
+                1,  // birthday count
+                LocalDate.of(2025,6,4)  // Wednesday
+        );
+        PricingResponse expected = new PricingResponse(
+                15000,
+                10.0,
+                10.0,
+                1,
+                10,
+                33075,
+                26.5
+        );
+        assertThat(service.calculate(req)).isEqualTo(expected);
+    }
+
+    @Test
+    void weekendCalculation_noBirthday() {
+        PricingRequest req = new PricingRequest(
+                10,
+                4,
+                0,
+                0,
+                LocalDate.of(2025,6,7) // Saturday
+        );
+        PricingResponse expected = new PricingResponse(
+                17000,
+                10.0,
+                0.0,
+                0,
+                10,
+                61200,
+                10.0
+        );
+        assertThat(service.calculate(req)).isEqualTo(expected);
+    }
+
+    @Test
+    void holidayCalculation_multipleDiscounts() {
+        PricingRequest req = new PricingRequest(
+                15,
+                5,
+                7,
+                2,
+                LocalDate.of(2025,9,18) // Holiday
+        );
+        PricingResponse expected = new PricingResponse(
+                26000,
+                10.0,
+                30.0,
+                1,
+                15,
+                101790,
+                21.7
+        );
+        assertThat(service.calculate(req)).isEqualTo(expected);
+    }
+}

--- a/pricing-service/src/test/java/cl/kartingrm/pricing_service/TariffServiceTest.java
+++ b/pricing-service/src/test/java/cl/kartingrm/pricing_service/TariffServiceTest.java
@@ -2,6 +2,7 @@ package cl.kartingrm.pricing_service;
 
 import cl.kartingrm.pricing_service.model.RateType;
 import cl.kartingrm.pricing_service.service.TariffService;
+import cl.kartingrm.pricing_service.repository.TariffConfigRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -13,6 +14,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest
 class TariffServiceTest {
     @Autowired TariffService tariff;
+    @Autowired TariffConfigRepository repo;
 
     @Test
     void weekendAndHolidayDetection() {
@@ -21,5 +23,10 @@ class TariffServiceTest {
 
         var holiday = tariff.forDate(LocalDate.of(2025,9,18), 10);
         assertThat(holiday.getRateType()).isEqualTo(RateType.HOLIDAY);
+    }
+
+    @Test
+    void initialSeedContainsNineRows() {
+        assertThat(repo.findAll()).hasSize(9);
     }
 }


### PR DESCRIPTION
## Summary
- add regression tests for PricingService
- test DiscountService edge cases
- verify DB seeding in TariffServiceTest
- document startup and testing steps in README

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6840f36fc4e8832ca5f19e25f0142bac