### PR TITLE
Use sessionDate in reservation service

### DIFF
--- a/reservation-service/src/main/java/cl/kartingrm/reservation_service/dto/CreateReservationRequest.java
+++ b/reservation-service/src/main/java/cl/kartingrm/reservation_service/dto/CreateReservationRequest.java
@@ -1,11 +1,12 @@
 package cl.kartingrm.reservation_service.dto;
 
+import java.time.LocalDate;
+
 public record CreateReservationRequest(
         int laps,
         int participants,
         String clientEmail,
         int clientVisits,
-        boolean weekend,
-        boolean holiday,
-        int birthdayCount
+        int birthdayCount,
+        LocalDate sessionDate
 ) {}

--- a/reservation-service/src/main/java/cl/kartingrm/reservation_service/service/ReservationService.java
+++ b/reservation-service/src/main/java/cl/kartingrm/reservation_service/service/ReservationService.java
@@ -14,7 +14,6 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
 
-import java.time.LocalDate;
 
 @Service
 @RequiredArgsConstructor
@@ -38,9 +37,11 @@ public class ReservationService {
     private PricingResponse callPricing(CreateReservationRequest req) {
         try {
             PricingRequest pricingReq = new PricingRequest(
-                    req.laps(), req.participants(),
-                    req.clientVisits(), req.birthdayCount(),
-                    LocalDate.now());
+                    req.laps(),
+                    req.participants(),
+                    req.clientVisits(),
+                    req.birthdayCount(),
+                    req.sessionDate());
 
             return rest.postForObject(
                     pricingUrl + "/api/pricing/calculate",

--- a/reservation-service/src/test/java/cl/kartingrm/reservation_service/ReservationServiceTest.java
+++ b/reservation-service/src/test/java/cl/kartingrm/reservation_service/ReservationServiceTest.java
@@ -1,10 +1,7 @@
 package cl.kartingrm.reservation_service;
 
-import cl.kartingrm.pricingclient.PricingResponse;
 import cl.kartingrm.reservation_service.controller.ReservationController;
 import cl.kartingrm.reservation_service.dto.ReservationResponse;
-import cl.kartingrm.reservation_service.model.Reservation;
-import cl.kartingrm.reservation_service.repository.ReservationRepository;
 import cl.kartingrm.reservation_service.service.ReservationService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,7 +9,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.web.client.RestTemplate;
 
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
@@ -25,9 +21,7 @@ class ReservationServiceTest {
 
     @Autowired MockMvc mvc;
 
-    @MockBean ReservationService service;      // <── NUEVO
-    @MockBean RestTemplate rest;
-    @MockBean ReservationRepository repo;
+    @MockBean ReservationService service;
 
     @Test
     void reservationCreated_ok() throws Exception {
@@ -41,17 +35,18 @@ class ReservationServiceTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
                    {
-                     "laps":15,
-                     "participants":4,
-                     "clientEmail":"a@b.com",
-                     "clientVisits":3,
-                     "weekend":false,
-                     "holiday":false,
-                     "birthdayCount":0
-                   }"""))
+                     "laps": 15,
+                     "participants": 4,
+                     "clientEmail": "a@b.com",
+                     "clientVisits": 3,
+                     "birthdayCount": 0,
+                     "sessionDate": "2025-06-07"
+                   }
+                """))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").value(1))
-                .andExpect(jsonPath("$.finalPrice").value(70200));
+                .andExpect(jsonPath("$.finalPrice").value(70200))
+                .andExpect(jsonPath("$.status").value("PENDING"));
 
         then(service).should().create(any());
     }


### PR DESCRIPTION
## Summary
- update `CreateReservationRequest` to send `sessionDate`
- forward `sessionDate` to pricing service
- adjust MVC test to accept `sessionDate`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_684104b81ab8832c98b90a247dcf089c