### PR TITLE
Add dev Docker Compose with config and discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,20 @@ KartingRM es un sistema modular de microservicios para la gestión de reservas e
   npm test
   ```
 
+
+## 🐳 Docker Compose "lista dev"
+
+Para levantar rápidamente los servicios existe el archivo `docker-compose.yml` que genera las imágenes de `pricing`, `reservation`, `config` y `discovery`. Las configuraciones se encuentran en `config-repo/`.
+
+```bash
+docker compose up --build
+```
+
+Revisa todos los servicios con:
+```bash
+docker compose logs -f
+```
+
 ## 🤝 Contribuciones
 
 ¡Bienvenidas! Para contribuir:

--- a/config-repo/pricing-service.properties
+++ b/config-repo/pricing-service.properties
@@ -1,0 +1,8 @@
+server.port=0
+spring.datasource.url=jdbc:mysql://pricing-db:3306/pricingdb?createDatabaseIfNotExist=true&serverTimezone=UTC
+spring.datasource.username=root
+spring.datasource.password=password
+spring.sql.init.mode=always
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.defer-datasource-initialization=true
+logging.level.org.springframework=INFO

--- a/config-repo/reservation-service.properties
+++ b/config-repo/reservation-service.properties
@@ -1,0 +1,7 @@
+server.port=0
+spring.datasource.url=jdbc:mysql://reservation-db:3306/reservationdb?createDatabaseIfNotExist=true&serverTimezone=UTC
+spring.datasource.username=root
+spring.datasource.password=password
+spring.jpa.hibernate.ddl-auto=update
+pricing.service.url=lb://pricing-service
+logging.level.org.springframework=INFO

--- a/config-server/Dockerfile
+++ b/config-server/Dockerfile
@@ -1,0 +1,10 @@
+FROM maven:3.9.6-eclipse-temurin-17 AS build
+WORKDIR /app
+COPY pom.xml .
+COPY src ./src
+RUN mvn -B package -DskipTests
+
+FROM eclipse-temurin:17-jre
+WORKDIR /app
+COPY --from=build /app/target/*.jar app.jar
+ENTRYPOINT ["java","-jar","/app/app.jar"]

--- a/config-server/pom.xml
+++ b/config-server/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.5.0</version>
+    </parent>
+    <groupId>cl.kartingrm</groupId>
+    <artifactId>config-server</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>config-server</name>
+    <properties>
+        <java.version>17</java.version>
+        <spring-cloud.version>2023.0.1</spring-cloud.version>
+    </properties>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-dependencies</artifactId>
+                <version>${spring-cloud.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-config-server</artifactId>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/config-server/src/main/java/cl/kartingrm/configserver/ConfigServerApplication.java
+++ b/config-server/src/main/java/cl/kartingrm/configserver/ConfigServerApplication.java
@@ -1,0 +1,13 @@
+package cl.kartingrm.configserver;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.config.server.EnableConfigServer;
+
+@SpringBootApplication
+@EnableConfigServer
+public class ConfigServerApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(ConfigServerApplication.class, args);
+    }
+}

--- a/config-server/src/main/resources/application.properties
+++ b/config-server/src/main/resources/application.properties
@@ -1,0 +1,3 @@
+server.port=8888
+spring.application.name=config-server
+spring.cloud.config.server.git.uri=file:///config-repo

--- a/discovery-server/Dockerfile
+++ b/discovery-server/Dockerfile
@@ -1,0 +1,10 @@
+FROM maven:3.9.6-eclipse-temurin-17 AS build
+WORKDIR /app
+COPY pom.xml .
+COPY src ./src
+RUN mvn -B package -DskipTests
+
+FROM eclipse-temurin:17-jre
+WORKDIR /app
+COPY --from=build /app/target/*.jar app.jar
+ENTRYPOINT ["java","-jar","/app/app.jar"]

--- a/discovery-server/pom.xml
+++ b/discovery-server/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.5.0</version>
+    </parent>
+    <groupId>cl.kartingrm</groupId>
+    <artifactId>discovery-server</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>discovery-server</name>
+    <properties>
+        <java.version>17</java.version>
+        <spring-cloud.version>2023.0.1</spring-cloud.version>
+    </properties>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-dependencies</artifactId>
+                <version>${spring-cloud.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-netflix-eureka-server</artifactId>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/discovery-server/src/main/java/cl/kartingrm/discoveryserver/DiscoveryServerApplication.java
+++ b/discovery-server/src/main/java/cl/kartingrm/discoveryserver/DiscoveryServerApplication.java
@@ -1,0 +1,13 @@
+package cl.kartingrm.discoveryserver;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.netflix.eureka.server.EnableEurekaServer;
+
+@SpringBootApplication
+@EnableEurekaServer
+public class DiscoveryServerApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(DiscoveryServerApplication.class, args);
+    }
+}

--- a/discovery-server/src/main/resources/application.properties
+++ b/discovery-server/src/main/resources/application.properties
@@ -1,0 +1,4 @@
+server.port=8761
+spring.application.name=discovery-service
+eureka.client.register-with-eureka=false
+eureka.client.fetch-registry=false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,56 @@
+version: '3.8'
+services:
+  config:
+    build: ./config-server
+    container_name: config
+    volumes:
+      - ./config-repo:/config-repo
+    ports:
+      - "8888:8888"
+
+  discovery:
+    build: ./discovery-server
+    container_name: discovery
+    depends_on:
+      - config
+    ports:
+      - "8761:8761"
+
+  pricing-db:
+    image: mysql:8
+    container_name: pricing-db
+    environment:
+      MYSQL_ROOT_PASSWORD: password
+      MYSQL_DATABASE: pricingdb
+    volumes:
+      - pricing-data:/var/lib/mysql
+
+  reservation-db:
+    image: mysql:8
+    container_name: reservation-db
+    environment:
+      MYSQL_ROOT_PASSWORD: password
+      MYSQL_DATABASE: reservationdb
+    volumes:
+      - reservation-data:/var/lib/mysql
+
+  pricing:
+    build: ./pricing-service
+    container_name: pricing
+    depends_on:
+      - config
+      - discovery
+      - pricing-db
+
+  reservation:
+    build: ./reservation-service
+    container_name: reservation
+    depends_on:
+      - config
+      - discovery
+      - reservation-db
+      - pricing
+
+volumes:
+  pricing-data:
+  reservation-data:

--- a/pricing-service/Dockerfile
+++ b/pricing-service/Dockerfile
@@ -1,0 +1,10 @@
+FROM maven:3.9.6-eclipse-temurin-17 AS build
+WORKDIR /app
+COPY pom.xml .
+COPY src ./src
+RUN mvn -B package -DskipTests
+
+FROM eclipse-temurin:17-jre
+WORKDIR /app
+COPY --from=build /app/target/*.jar app.jar
+ENTRYPOINT ["java","-jar","/app/app.jar"]

--- a/pricing-service/pom.xml
+++ b/pricing-service/pom.xml
@@ -18,9 +18,22 @@
 	<name>pricing-service</name>
 	<description>Servicio de cálculo de precios</description>
 
-	<properties>
-		<java.version>17</java.version>
-	</properties>
+        <properties>
+                <java.version>17</java.version>
+                <spring-cloud.version>2023.0.1</spring-cloud.version>
+        </properties>
+
+        <dependencyManagement>
+                <dependencies>
+                        <dependency>
+                                <groupId>org.springframework.cloud</groupId>
+                                <artifactId>spring-cloud-dependencies</artifactId>
+                                <version>${spring-cloud.version}</version>
+                                <type>pom</type>
+                                <scope>import</scope>
+                        </dependency>
+                </dependencies>
+        </dependencyManagement>
 
 	<dependencies>
 		<!-- Web -->
@@ -47,12 +60,22 @@
 		</dependency>
 
 		<!-- Lombok (procesador de anotaciones) -->
-		<dependency>
-			<groupId>org.projectlombok</groupId>
-			<artifactId>lombok</artifactId>
-			<version>1.18.38</version>
-			<scope>provided</scope>
-		</dependency>
+                <dependency>
+                        <groupId>org.projectlombok</groupId>
+                        <artifactId>lombok</artifactId>
+                        <version>1.18.38</version>
+                        <scope>provided</scope>
+                </dependency>
+
+                <!-- Spring Cloud -->
+                <dependency>
+                        <groupId>org.springframework.cloud</groupId>
+                        <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>org.springframework.cloud</groupId>
+                        <artifactId>spring-cloud-starter-config</artifactId>
+                </dependency>
 
 		<!-- Tests -->
 		<dependency>

--- a/pricing-service/src/main/resources/application.properties
+++ b/pricing-service/src/main/resources/application.properties
@@ -1,18 +1,1 @@
 spring.application.name=pricing-service
-server.port=8081
-
-# Datasource
-spring.datasource.url=jdbc:mysql://localhost:3306/pricingdb?createDatabaseIfNotExist=true&serverTimezone=UTC
-spring.jpa.hibernate.ddl-auto=update
-spring.sql.init.mode=always
-spring.datasource.username=root
-spring.datasource.password=password
-
-# Que JPA genere tablas pero no borre datos
-
-
-# >??? Estas dos líneas son la clave para que data.sql se ejecute en MySQL ???<
-spring.jpa.defer-datasource-initialization=true
-
-# Logs
-logging.level.org.springframework=INFO

--- a/pricing-service/src/main/resources/bootstrap.properties
+++ b/pricing-service/src/main/resources/bootstrap.properties
@@ -1,0 +1,3 @@
+spring.application.name=pricing-service
+spring.config.import=configserver:http://config:8888
+eureka.client.service-url.defaultZone=http://discovery:8761/eureka/

--- a/reservation-service/Dockerfile
+++ b/reservation-service/Dockerfile
@@ -1,0 +1,10 @@
+FROM maven:3.9.6-eclipse-temurin-17 AS build
+WORKDIR /app
+COPY pom.xml .
+COPY src ./src
+RUN mvn -B package -DskipTests
+
+FROM eclipse-temurin:17-jre
+WORKDIR /app
+COPY --from=build /app/target/*.jar app.jar
+ENTRYPOINT ["java","-jar","/app/app.jar"]

--- a/reservation-service/pom.xml
+++ b/reservation-service/pom.xml
@@ -18,9 +18,22 @@
 	<name>reservation-service</name>
 	<description>Servicio reservaciones</description>
 
-	<properties>
-		<java.version>17</java.version>
-	</properties>
+        <properties>
+                <java.version>17</java.version>
+                <spring-cloud.version>2023.0.1</spring-cloud.version>
+        </properties>
+
+        <dependencyManagement>
+                <dependencies>
+                        <dependency>
+                                <groupId>org.springframework.cloud</groupId>
+                                <artifactId>spring-cloud-dependencies</artifactId>
+                                <version>${spring-cloud.version}</version>
+                                <type>pom</type>
+                                <scope>import</scope>
+                        </dependency>
+                </dependencies>
+        </dependencyManagement>
 
 	<dependencies>
 		<!-- Web -->
@@ -47,12 +60,22 @@
 		</dependency>
 
 		<!-- Lombok (procesador de anotaciones) -->
-		<dependency>
-			<groupId>org.projectlombok</groupId>
-			<artifactId>lombok</artifactId>
-			<version>1.18.38</version>
-			<scope>provided</scope>
-		</dependency>
+                <dependency>
+                        <groupId>org.projectlombok</groupId>
+                        <artifactId>lombok</artifactId>
+                        <version>1.18.38</version>
+                        <scope>provided</scope>
+                </dependency>
+
+                <!-- Spring Cloud -->
+                <dependency>
+                        <groupId>org.springframework.cloud</groupId>
+                        <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>org.springframework.cloud</groupId>
+                        <artifactId>spring-cloud-starter-config</artifactId>
+                </dependency>
 
 		<!-- Tests -->
 		<dependency>

--- a/reservation-service/src/main/resources/application.properties
+++ b/reservation-service/src/main/resources/application.properties
@@ -1,10 +1,1 @@
 spring.application.name=reservation-service
-
-spring.datasource.username=root
-spring.datasource.password=password
-
-
-server.port=8082
-spring.datasource.url=jdbc:mysql://localhost:3306/reservationdb?createDatabaseIfNotExist=true&serverTimezone=UTC
-spring.jpa.hibernate.ddl-auto=update
-pricing.service.url=http://localhost:8081

--- a/reservation-service/src/main/resources/bootstrap.properties
+++ b/reservation-service/src/main/resources/bootstrap.properties
@@ -1,0 +1,3 @@
+spring.application.name=reservation-service
+spring.config.import=configserver:http://config:8888
+eureka.client.service-url.defaultZone=http://discovery:8761/eureka/


### PR DESCRIPTION
## Summary
- add Spring Cloud Config Server and Eureka Server modules
- add Dockerfiles for pricing and reservation services
- externalize configuration under `config-repo`
- create Docker Compose file for dev environment
- document Docker Compose usage in README

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68419f86f82c832c9c889a234fbce2d4