### PR TITLE
Fix RestTemplate timeouts for Boot 3.2

### DIFF
--- a/reservation-service/src/main/java/cl/kartingrm/reservation_service/config/RestConfig.java
+++ b/reservation-service/src/main/java/cl/kartingrm/reservation_service/config/RestConfig.java
@@ -13,9 +13,9 @@ public class RestConfig {
 
     @Bean
     public RestTemplate restTemplate(RestTemplateBuilder builder) {
-        return builder                       // nuevos métodos (Spring Boot ≥ 3.4)
-                .connectTimeout(Duration.ofSeconds(3))
-                .readTimeout(Duration.ofSeconds(5))
+        return builder
+                .setConnectTimeout(Duration.ofSeconds(3))
+                .setReadTimeout(Duration.ofSeconds(5))
                 .build();
     }
 }


### PR DESCRIPTION
## Summary
- use `setConnectTimeout` and `setReadTimeout` in `RestConfig`

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.5)*

------
https://chatgpt.com/codex/tasks/task_e_6841b9ab97f4832cae15eaf28b5adbee