### PR TITLE
Add health checks for Config Server

### DIFF
--- a/config-server/pom.xml
+++ b/config-server/pom.xml
@@ -31,6 +31,10 @@
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-config-server</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/config-server/src/main/resources/application.properties
+++ b/config-server/src/main/resources/application.properties
@@ -4,3 +4,4 @@ spring.application.name=config-server
 # Activamos almacenamiento nativo en una carpeta
 spring.profiles.active=native
 spring.cloud.config.server.native.search-locations=file:///config-repo
+management.endpoints.web.exposure.include=health,info

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,11 @@ services:
       - ./config-repo:/config-repo
     ports:
       - "8888:8888"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8888/actuator/health"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
 
   discovery:
     build: ./discovery-server
@@ -37,18 +42,27 @@ services:
     build: ./pricing-service
     container_name: pricing
     depends_on:
-      - config
-      - discovery
-      - pricing-db
+      config:
+        condition: service_healthy
+      discovery:
+        condition: service_started
+      pricing-db:
+        condition: service_started
+    restart: on-failure
 
   reservation:
     build: ./reservation-service
     container_name: reservation
     depends_on:
-      - config
-      - discovery
-      - reservation-db
-      - pricing
+      config:
+        condition: service_healthy
+      discovery:
+        condition: service_started
+      reservation-db:
+        condition: service_started
+      pricing:
+        condition: service_started
+    restart: on-failure
 
 volumes:
   pricing-data:


### PR DESCRIPTION
## Summary
- expose `/actuator/health` in Config Server and add actuator dependency
- add healthcheck for `config` container and wait for it before starting others
- restart `pricing` and `reservation` on failure

## Testing
- `mvn -q test` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_6841cd0aa48c832c8a8c0421676727e5