### PR TITLE
Fix RestTemplate load balancing and tweak docker compose

### DIFF
--- a/config-repo/discovery-service.properties
+++ b/config-repo/discovery-service.properties
@@ -4,3 +4,4 @@ spring.application.name=discovery-service
 # habilitar auto-registro
 eureka.client.register-with-eureka=true
 eureka.client.fetch-registry=true        # opcional, pero práctico para ver las otras instancias en /actuator
+spring.jpa.open-in-view=false

--- a/config-repo/pricing-service.properties
+++ b/config-repo/pricing-service.properties
@@ -5,4 +5,5 @@ spring.datasource.password=password
 spring.sql.init.mode=always
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.defer-datasource-initialization=true
+spring.jpa.open-in-view=false
 logging.level.org.springframework=INFO

--- a/config-repo/reservation-service.properties
+++ b/config-repo/reservation-service.properties
@@ -3,5 +3,6 @@ spring.datasource.url=jdbc:mysql://reservation-db:3306/reservationdb?createDatab
 spring.datasource.username=root
 spring.datasource.password=password
 spring.jpa.hibernate.ddl-auto=update
+spring.jpa.open-in-view=false
 pricing.service.url=lb://pricing-service
 logging.level.org.springframework=INFO

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,11 @@ services:
       - config
     ports:
       - "8761:8761"
+    healthcheck:
+      test: ["CMD", "curl","-f","http://localhost:8761/actuator/health"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
 
   pricing-db:
     image: mysql:8
@@ -49,6 +54,13 @@ services:
       pricing-db:
         condition: service_started
     restart: on-failure
+    ports:
+      - "8081:0"
+    healthcheck:
+      test: ["CMD", "curl","-f","http://localhost:8081/actuator/health"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
 
   reservation:
     build: ./reservation-service
@@ -63,6 +75,13 @@ services:
       pricing:
         condition: service_started
     restart: on-failure
+    ports:
+      - "8082:0"
+    healthcheck:
+      test: ["CMD", "curl","-f","http://localhost:8082/actuator/health"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
 
 volumes:
   pricing-data:

--- a/reservation-service/src/main/java/cl/kartingrm/reservation_service/config/RestConfig.java
+++ b/reservation-service/src/main/java/cl/kartingrm/reservation_service/config/RestConfig.java
@@ -4,6 +4,7 @@ import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.cloud.client.loadbalancer.LoadBalanced;
 
 import java.time.Duration;
 
@@ -12,6 +13,7 @@ import java.time.Duration;
 public class RestConfig {
 
     @Bean
+    @LoadBalanced
     public RestTemplate restTemplate(RestTemplateBuilder builder) {
         return builder
                 .setConnectTimeout(Duration.ofSeconds(3))


### PR DESCRIPTION
## Summary
- add `@LoadBalanced` RestTemplate bean so Reservation Service can call other MS via `lb://`
- expose Pricing and Reservation services ports and add health checks
- disable `open-in-view` in config properties

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*


------
https://chatgpt.com/codex/tasks/task_e_6841d9b7f140832ca26d6186fa11991f