### PR TITLE
Remove fixed port mapping for dynamic services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,13 +54,7 @@ services:
       pricing-db:
         condition: service_started
     restart: on-failure
-    ports:
-      - "8081:0"
-    healthcheck:
-      test: ["CMD", "curl","-f","http://localhost:8081/actuator/health"]
-      interval: 5s
-      timeout: 3s
-      retries: 10
+    # Expose no fixed port; service registers with Eureka using a random port
 
   reservation:
     build: ./reservation-service
@@ -75,13 +69,7 @@ services:
       pricing:
         condition: service_started
     restart: on-failure
-    ports:
-      - "8082:0"
-    healthcheck:
-      test: ["CMD", "curl","-f","http://localhost:8082/actuator/health"]
-      interval: 5s
-      timeout: 3s
-      retries: 10
+    # Expose no fixed port; service registers with Eureka using a random port
 
 volumes:
   pricing-data:


### PR DESCRIPTION
## Summary
- remove explicit port mappings for pricing and reservation services in docker-compose so they can run with `server.port=0`
- keep config with random port setting

## Testing
- `docker compose config` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6841dc2a358c832c863e95fe49417a29