### PR TITLE
Fix config server and health checks

### DIFF
--- a/config-repo/discovery-service.properties
+++ b/config-repo/discovery-service.properties
@@ -1,7 +1,2 @@
 server.port=8761
 spring.application.name=discovery-service
-
-# habilitar auto-registro
-eureka.client.register-with-eureka=true
-eureka.client.fetch-registry=true        # opcional, pero práctico para ver las otras instancias en /actuator
-spring.jpa.open-in-view=false

--- a/config-repo/pricing-service.properties
+++ b/config-repo/pricing-service.properties
@@ -7,3 +7,5 @@ spring.jpa.hibernate.ddl-auto=update
 spring.jpa.defer-datasource-initialization=true
 spring.jpa.open-in-view=false
 logging.level.org.springframework=INFO
+management.endpoints.web.exposure.include=health,info
+management.endpoint.health.show-details=always

--- a/config-repo/reservation-service.properties
+++ b/config-repo/reservation-service.properties
@@ -6,3 +6,5 @@ spring.jpa.hibernate.ddl-auto=update
 spring.jpa.open-in-view=false
 pricing.service.url=lb://pricing-service
 logging.level.org.springframework=INFO
+management.endpoints.web.exposure.include=health,info
+management.endpoint.health.show-details=always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,11 @@ services:
         condition: service_started
     restart: on-failure
     # Expose no fixed port; service registers with Eureka using a random port
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
 
   reservation:
     build: ./reservation-service
@@ -70,6 +75,11 @@ services:
         condition: service_started
     restart: on-failure
     # Expose no fixed port; service registers with Eureka using a random port
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
 
 volumes:
   pricing-data:

--- a/pricing-service/src/main/resources/application.properties
+++ b/pricing-service/src/main/resources/application.properties
@@ -8,3 +8,6 @@ spring.cloud.config.fail-fast=true
 
 # Eureka
 eureka.client.service-url.defaultZone=http://discovery:8761/eureka/
+
+management.endpoints.web.exposure.include=health,info
+management.endpoint.health.show-details=always

--- a/reservation-service/src/main/resources/application.properties
+++ b/reservation-service/src/main/resources/application.properties
@@ -7,3 +7,6 @@ spring.cloud.config.retry.max-attempts=10
 spring.cloud.config.fail-fast=true
 
 eureka.client.service-url.defaultZone=http://discovery:8761/eureka/
+
+management.endpoints.web.exposure.include=health,info
+management.endpoint.health.show-details=always


### PR DESCRIPTION
## Summary
- clean discovery service remote config
- enable actuator endpoints and health checks
- adjust Docker Compose for pricing and reservation

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684232a46c3c832caafb318329027500