### PR TITLE
Add actuator endpoints and transaction fix

### DIFF
--- a/discovery-server/pom.xml
+++ b/discovery-server/pom.xml
@@ -31,6 +31,10 @@
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-netflix-eureka-server</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/discovery-server/src/main/resources/application.properties
+++ b/discovery-server/src/main/resources/application.properties
@@ -1,6 +1,8 @@
-server.port=8761
 spring.application.name=discovery-service
 eureka.client.register-with-eureka=false
 eureka.client.fetch-registry=false
+management.server.port=8080
+management.endpoints.web.exposure.include=health,info
+management.endpoint.health.show-details=always
 
 spring.config.import=optional:configserver:http://config:8888

--- a/pricing-service/pom.xml
+++ b/pricing-service/pom.xml
@@ -53,11 +53,17 @@
 			<scope>runtime</scope>
 		</dependency>
 
-		<!-- Validación de DTOs -->
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-validation</artifactId>
-		</dependency>
+                <!-- Validación de DTOs -->
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-validation</artifactId>
+                </dependency>
+
+                <!-- Endpoints de gestión -->
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-actuator</artifactId>
+                </dependency>
 
 		<!-- Lombok (procesador de anotaciones) -->
                 <dependency>

--- a/pricing-service/src/main/resources/application.properties
+++ b/pricing-service/src/main/resources/application.properties
@@ -8,6 +8,7 @@ spring.cloud.config.fail-fast=true
 
 # Eureka
 eureka.client.service-url.defaultZone=http://discovery:8761/eureka/
+management.server.port=8080
 
 management.endpoints.web.exposure.include=health,info
 management.endpoint.health.show-details=always

--- a/reservation-service/pom.xml
+++ b/reservation-service/pom.xml
@@ -53,11 +53,17 @@
 			<scope>runtime</scope>
 		</dependency>
 
-		<!-- Validación de DTOs -->
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-validation</artifactId>
-		</dependency>
+                <!-- Validación de DTOs -->
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-validation</artifactId>
+                </dependency>
+
+                <!-- Endpoints de gestión -->
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-actuator</artifactId>
+                </dependency>
 
 		<!-- Lombok (procesador de anotaciones) -->
                 <dependency>

--- a/reservation-service/src/main/java/cl/kartingrm/reservation_service/service/ReservationService.java
+++ b/reservation-service/src/main/java/cl/kartingrm/reservation_service/service/ReservationService.java
@@ -25,6 +25,7 @@ public class ReservationService {
     @Value("${pricing.service.url}")           // http://localhost:8081
     private String pricingUrl;
 
+    @Transactional
     public ReservationResponse create(CreateReservationRequest req) {
         // 1) Consultar microservicio de precios FUERA de transacción
         PricingResponse p = callPricing(req);
@@ -55,7 +56,6 @@ public class ReservationService {
      * Transacción corta — solo inserción en una tabla local;
      * admite REQUIRES_NEW para no propagar rollback a llamada externa ya realizada.
      */
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
     protected Reservation saveReservation(CreateReservationRequest req, PricingResponse p) {
         Reservation r = Reservation.builder()
                 .laps(req.laps())

--- a/reservation-service/src/main/resources/application.properties
+++ b/reservation-service/src/main/resources/application.properties
@@ -8,5 +8,6 @@ spring.cloud.config.fail-fast=true
 
 eureka.client.service-url.defaultZone=http://discovery:8761/eureka/
 
+management.server.port=8080
 management.endpoints.web.exposure.include=health,info
 management.endpoint.health.show-details=always

--- a/tools/ports.sh
+++ b/tools/ports.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+get_port() {
+  curl -s "http://localhost:8761/eureka/apps/${1^^}" \
+  | grep -oP '(?<=<port enabled="true">)\d+' | head -1
+}
+
+PPORT=$(get_port pricing-service)
+RPORT=$(get_port reservation-service)
+
+echo "Pricing      :$PPORT"
+echo "Reservation  :$RPORT"
+


### PR DESCRIPTION
## Summary
- add Spring Boot Actuator to discovery, pricing and reservation services
- expose `/actuator/health` on port 8080 for container health checks
- remove duplicate discovery `server.port` config
- ensure JPA transaction in `ReservationService`
- include helper script `tools/ports.sh`

## Testing
- `mvn -q -f pricing-service/pom.xml dependency:go-offline package -DskipTests` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684236cc9c0c832ca654046c241a586d