### PR TITLE
Fix transaction isolation in ReservationService

### DIFF
--- a/reservation-service/src/main/java/cl/kartingrm/reservation_service/service/ReservationPersister.java
+++ b/reservation-service/src/main/java/cl/kartingrm/reservation_service/service/ReservationPersister.java
@@ -1,0 +1,30 @@
+package cl.kartingrm.reservation_service.service;
+
+import cl.kartingrm.pricingclient.PricingResponse;
+import cl.kartingrm.reservation_service.dto.CreateReservationRequest;
+import cl.kartingrm.reservation_service.model.Reservation;
+import cl.kartingrm.reservation_service.repository.ReservationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ReservationPersister {
+    private final ReservationRepository repo;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public Reservation save(CreateReservationRequest req, PricingResponse p) {
+        Reservation r = Reservation.builder()
+                .laps(req.laps())
+                .participants(req.participants())
+                .clientEmail(req.clientEmail())
+                .basePrice((int) (p.baseUnit() * req.participants()))
+                .discountPercent((int) p.totalDiscountPct())
+                .finalPrice(p.finalPrice())
+                .status("PENDING")
+                .build();
+        return repo.save(r);
+    }
+}


### PR DESCRIPTION
## Summary
- inject a dedicated `ReservationPersister` service
- move transactional `save` logic to the new bean
- call the persister from `ReservationService`

## Testing
- `./mvnw -q test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68425d54fedc832cb5f22520cca00b45