### PR TITLE
Fix discovery registration timing

### DIFF
--- a/discovery-server/src/main/resources/application.properties
+++ b/discovery-server/src/main/resources/application.properties
@@ -6,3 +6,8 @@ management.endpoints.web.exposure.include=health,info
 management.endpoint.health.show-details=always
 
 spring.config.import=optional:configserver:http://config:8888
+
+# Retry configuration for config server
+spring.cloud.config.retry.initial-interval=2000
+spring.cloud.config.retry.max-attempts=10
+spring.cloud.config.fail-fast=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,8 @@ services:
     build: ./discovery-server
     container_name: discovery
     depends_on:
-      - config
+      config:
+        condition: service_healthy
     ports:
       - "8761:8761"
     healthcheck:


### PR DESCRIPTION
## Summary
- ensure discovery service waits for config server startup
- retry config server connection from discovery service

## Testing
- `./mvnw -q test` (pricing-service) *(fails: Could not transfer artifact)*
- `./mvnw -q test` (reservation-service) *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_6842660536a8832cb0f8dbe0f0b86d48