### PR TITLE
Fix service ports and unify Actuator

### DIFF
--- a/config-repo/pricing-service.properties
+++ b/config-repo/pricing-service.properties
@@ -1,4 +1,4 @@
-server.port=0
+server.port=8080
 spring.datasource.url=jdbc:mysql://pricing-db:3306/pricingdb?createDatabaseIfNotExist=true&serverTimezone=UTC
 spring.datasource.username=root
 spring.datasource.password=password

--- a/config-repo/reservation-service.properties
+++ b/config-repo/reservation-service.properties
@@ -1,4 +1,4 @@
-server.port=0
+server.port=8080
 spring.datasource.url=jdbc:mysql://reservation-db:3306/reservationdb?createDatabaseIfNotExist=true&serverTimezone=UTC
 spring.datasource.username=root
 spring.datasource.password=password

--- a/discovery-server/src/main/resources/application.properties
+++ b/discovery-server/src/main/resources/application.properties
@@ -3,8 +3,8 @@ spring.application.name=discovery-service
 # Puerto principal de Eureka
 server.port=8761
 
-# Puerto del Actuator (opcional, separado)
-management.server.port=8081
+# Puerto del Actuator; sin puerto separado para facilitar pruebas
+# management.server.port=8081
 management.endpoints.web.exposure.include=health,info
 management.endpoint.health.show-details=always
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     ports:
       - "8761:8761"
     healthcheck:
-      test: ["CMD", "curl","-f","http://localhost:8081/actuator/health"]
+      test: ["CMD", "curl","-f","http://localhost:8761/actuator/health"]
       interval: 5s
       timeout: 3s
       retries: 10
@@ -55,7 +55,8 @@ services:
       pricing-db:
         condition: service_started
     restart: on-failure
-    # Expose no fixed port; service registers with Eureka using a random port
+    ports:
+      - "8082:8080"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
       interval: 10s
@@ -75,7 +76,8 @@ services:
       pricing:
         condition: service_started
     restart: on-failure
-    # Expose no fixed port; service registers with Eureka using a random port
+    ports:
+      - "8083:8080"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
       interval: 10s


### PR DESCRIPTION
## Summary
- expose microservice ports on container port 8080 and map them via Docker Compose
- keep Actuator on the same port as the application
- adjust discovery server config and health check

## Testing
- `mvn -q test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684347091590832ca371e6b714eb5a10