### PR TITLE
Document dynamic port usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,40 @@ Revisa todos los servicios con:
 docker compose logs -f
 ```
 
+Comprueba que el registro de servicios está disponible:
+
+```bash
+curl -f http://localhost:8081/actuator/health
+```
+
+### Probar servicios con puertos dinámicos
+
+Los microservicios `pricing` y `reservation` arrancan con `server.port=0`,
+por lo que su puerto cambia en cada ejecución. Puedes invocarlos de dos
+maneras:
+
+1. **Desde otro contenedor**:
+
+   ```bash
+   docker compose exec reservation \
+     curl -s -X POST http://pricing-service/api/pricing/calculate \
+          -H 'Content-Type: application/json' \
+          -d '{"laps":10,"participants":3,"clientVisits":1,"birthdayCount":0,"sessionDate":"2025-06-07"}'
+   ```
+
+   El alias DNS `pricing-service` se resuelve internamente mediante Eureka.
+
+2. **Desde el host** usando `tools/ports.sh` para descubrir la IP y el
+   puerto asignado:
+
+   ```bash
+   ./tools/ports.sh pricing-service
+   # salida de ejemplo: curl http://172.19.0.4:39543/api/pricing/...
+   ```
+
+   Ejecuta el comando mostrado para interactuar con la API desde tu
+   terminal.
+
 ## 🤝 Contribuciones
 
 ¡Bienvenidas! Para contribuir:

--- a/tools/ports.sh
+++ b/tools/ports.sh
@@ -1,12 +1,9 @@
 #!/usr/bin/env bash
-get_port() {
-  curl -s "http://localhost:8761/eureka/apps/${1^^}" \
-  | grep -oP '(?<=<port enabled="true">)\d+' | head -1
-}
+EUREKA=http://localhost:8761/eureka
 
-PPORT=$(get_port pricing-service)
-RPORT=$(get_port reservation-service)
+lookup() { curl -s "$EUREKA/apps/${1^^}" | tr -d '\n'; }
+ip()   { lookup "$1" | grep -oP '(?<=<ipAddr>)[^<]+'; }
+port() { lookup "$1" | grep -oP '(?<=<port[^>]*>)[0-9]+'; }
 
-echo "Pricing      :$PPORT"
-echo "Reservation  :$RPORT"
-
+svc=${1:-pricing-service}
+echo "curl http://$(ip $svc):$(port $svc)/api/${svc%-service}/..."


### PR DESCRIPTION
## Summary
- explain how to reach services with random ports
- show service health check on port 8081
- provide new `tools/ports.sh` script returning ip:port

## Testing
- `mvn -q test` *(fails: Could not download spring-boot-parent)*

------
https://chatgpt.com/codex/tasks/task_e_68434ebcc314832c983819056a490345