### PR TITLE
Integrate pricing with client-service

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ maneras:
    docker compose exec reservation \
      curl -s -X POST http://pricing-service/api/pricing/calculate \
           -H 'Content-Type: application/json' \
-          -d '{"laps":10,"participants":3,"clientVisits":1,"birthdayCount":0,"sessionDate":"2025-06-07"}'
+          -d '{"laps":10,"participants":3,"clientEmail":"demo@demo.cl","birthdayCount":0,"sessionDate":"2025-06-07"}'
    ```
 
    El alias DNS `pricing-service` se resuelve internamente mediante Eureka.

--- a/pricing-service/src/main/java/cl/kartingrm/pricing_service/config/RestConfig.java
+++ b/pricing-service/src/main/java/cl/kartingrm/pricing_service/config/RestConfig.java
@@ -1,0 +1,17 @@
+package cl.kartingrm.pricing_service.config;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.cloud.client.loadbalancer.LoadBalanced;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestConfig {
+
+    @Bean
+    @LoadBalanced
+    public RestTemplate restTemplate(RestTemplateBuilder builder) {
+        return builder.build();
+    }
+}

--- a/pricing-service/src/main/java/cl/kartingrm/pricing_service/dto/PricingRequest.java
+++ b/pricing-service/src/main/java/cl/kartingrm/pricing_service/dto/PricingRequest.java
@@ -5,7 +5,7 @@ import java.time.LocalDate;
 public record PricingRequest(
         int laps,
         int participants,
-        int clientVisits,
+        String clientEmail,
         int birthdayCount,
-        LocalDate sessionDate        // ¡nuevo!
+        LocalDate sessionDate
 ) {}

--- a/pricing-service/src/test/java/cl/kartingrm/pricing_service/PricingServiceTest.java
+++ b/pricing-service/src/test/java/cl/kartingrm/pricing_service/PricingServiceTest.java
@@ -6,11 +6,14 @@ import cl.kartingrm.pricing_service.service.PricingService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.client.RestTemplate;
 
 import java.time.LocalDate;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
 
 @SpringBootTest
 @ActiveProfiles("test")
@@ -19,15 +22,21 @@ class PricingServiceTest {
     @Autowired
     PricingService service;
 
+    @MockBean
+    RestTemplate rest;
+
     @Test
     void weekdayCalculation_withDiscounts() {
         PricingRequest req = new PricingRequest(
                 10, // laps
                 3,  // participants
-                2,  // client visits
+                "a@b.com",
                 1,  // birthday count
                 LocalDate.of(2025,6,4)  // Wednesday
         );
+        given(rest.getForObject("http://client-service/api/clients/{email}/visits",
+                Integer.class, "a@b.com"))
+                .willReturn(2);
         PricingResponse expected = new PricingResponse(
                 15000,
                 10.0,
@@ -45,10 +54,13 @@ class PricingServiceTest {
         PricingRequest req = new PricingRequest(
                 10,
                 4,
-                0,
+                "c@d.com",
                 0,
                 LocalDate.of(2025,6,7) // Saturday
         );
+        given(rest.getForObject("http://client-service/api/clients/{email}/visits",
+                Integer.class, "c@d.com"))
+                .willReturn(0);
         PricingResponse expected = new PricingResponse(
                 17000,
                 10.0,
@@ -66,10 +78,13 @@ class PricingServiceTest {
         PricingRequest req = new PricingRequest(
                 15,
                 5,
-                7,
+                "e@f.com",
                 2,
                 LocalDate.of(2025,9,18) // Holiday
         );
+        given(rest.getForObject("http://client-service/api/clients/{email}/visits",
+                Integer.class, "e@f.com"))
+                .willReturn(7);
         PricingResponse expected = new PricingResponse(
                 26000,
                 10.0,

--- a/reservation-service/src/main/java/cl/kartingrm/pricingclient/PricingRequest.java
+++ b/reservation-service/src/main/java/cl/kartingrm/pricingclient/PricingRequest.java
@@ -9,7 +9,7 @@ import java.time.LocalDate;
 public record PricingRequest(
         int laps,
         int participants,
-        int clientVisits,
+        String clientEmail,
         int birthdayCount,
         LocalDate sessionDate      // mismo orden que en pricing-service
 ) {}

--- a/reservation-service/src/main/java/cl/kartingrm/reservation_service/dto/CreateReservationRequest.java
+++ b/reservation-service/src/main/java/cl/kartingrm/reservation_service/dto/CreateReservationRequest.java
@@ -6,7 +6,6 @@ public record CreateReservationRequest(
         int laps,
         int participants,
         String clientEmail,
-        int clientVisits,
         int birthdayCount,
         LocalDate sessionDate
 ) {}

--- a/reservation-service/src/main/java/cl/kartingrm/reservation_service/service/ReservationService.java
+++ b/reservation-service/src/main/java/cl/kartingrm/reservation_service/service/ReservationService.java
@@ -21,10 +21,12 @@ public class ReservationService {
     private final RestTemplate rest;
 
     private static final String PRICING_URL = "http://pricing-service";
+    private static final String CLIENT_URL = "http://client-service";
 
     public ReservationResponse create(CreateReservationRequest req) {
         PricingResponse p = callPricing(req);
         Reservation saved = persister.save(req, p);
+        rest.postForLocation(CLIENT_URL + "/api/clients/{email}/visits", null, req.clientEmail());
         return new ReservationResponse(saved.getId(), saved.getFinalPrice(), saved.getStatus());
     }
 
@@ -33,7 +35,7 @@ public class ReservationService {
             PricingRequest pricingReq = new PricingRequest(
                     req.laps(),
                     req.participants(),
-                    req.clientVisits(),
+                    req.clientEmail(),
                     req.birthdayCount(),
                     req.sessionDate());
 

--- a/reservation-service/src/test/java/cl/kartingrm/reservation_service/ReservationServiceTest.java
+++ b/reservation-service/src/test/java/cl/kartingrm/reservation_service/ReservationServiceTest.java
@@ -38,10 +38,9 @@ class ReservationServiceTest {
                      "laps": 15,
                      "participants": 4,
                      "clientEmail": "a@b.com",
-                     "clientVisits": 3,
                      "birthdayCount": 0,
                      "sessionDate": "2025-06-07"
-                   }
+                  }
                 """))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").value(1))


### PR DESCRIPTION
## Summary
- update README example to use client email
- add load-balanced `RestTemplate` config to pricing-service
- update pricing DTOs to reference email instead of visit count
- call client-service for visit count in pricing-service
- register visits from reservation-service
- adjust DTOs and tests accordingly

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68435b671b10832caffa1c5c6849b749