### PR TITLE
Fix Maven parent path for client-service

### DIFF
--- a/client-service/pom.xml
+++ b/client-service/pom.xml
@@ -8,7 +8,7 @@
         <groupId>cl.kartingrm</groupId>
         <artifactId>kartingrm-parent</artifactId>
         <version>0.0.1-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <artifactId>client-service</artifactId>


### PR DESCRIPTION
## Summary
- fix parent `pom.xml` location in client-service

## Testing
- `mvn -q -pl client-service -am verify` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843877e5238832cb43a3f209df0aad4