### PR TITLE
Fix Docker build for multi-module project

### DIFF
--- a/client-service/Dockerfile
+++ b/client-service/Dockerfile
@@ -1,12 +1,13 @@
 FROM maven:3.9.9-eclipse-temurin-17 AS build
 WORKDIR /app
-COPY pom.xml .
-COPY src ./src
+# Copia todo el proyecto para resolver el POM padre
+COPY . .
+WORKDIR /app/client-service
 RUN mvn clean package -DskipTests
 
 FROM eclipse-temurin:17-jre-alpine
 WORKDIR /app
-COPY --from=build /app/target/*.jar app.jar
+COPY --from=build /app/client-service/target/*.jar app.jar
 ENV JAVA_TOOL_OPTIONS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=60"
 EXPOSE 8080 9090
 ENTRYPOINT ["java","-jar","app.jar"]

--- a/config-server/Dockerfile
+++ b/config-server/Dockerfile
@@ -1,11 +1,12 @@
 FROM maven:3.9.9-eclipse-temurin-17 AS build
 WORKDIR /app
-COPY pom.xml .
-COPY src ./src
+# Copia todo el proyecto para resolver el POM padre
+COPY . .
+WORKDIR /app/config-server
 RUN mvn -B package -DskipTests
 
 FROM eclipse-temurin:17-jre
 WORKDIR /app
-COPY --from=build /app/target/*.jar app.jar
+COPY --from=build /app/config-server/target/*.jar app.jar
 ENV JAVA_TOOL_OPTIONS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=60"
 ENTRYPOINT ["java","-jar","/app/app.jar"]

--- a/discovery-server/Dockerfile
+++ b/discovery-server/Dockerfile
@@ -1,11 +1,12 @@
 FROM maven:3.9.9-eclipse-temurin-17 AS build
 WORKDIR /app
-COPY pom.xml .
-COPY src ./src
+# Copia todo el proyecto para resolver el POM padre
+COPY . .
+WORKDIR /app/discovery-server
 RUN mvn -B package -DskipTests
 
 FROM eclipse-temurin:17-jre
 WORKDIR /app
-COPY --from=build /app/target/*.jar app.jar
+COPY --from=build /app/discovery-server/target/*.jar app.jar
 ENV JAVA_TOOL_OPTIONS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=60"
 ENTRYPOINT ["java","-jar","/app/app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 services:
   config:
-    build: ./config-server
+    build:
+      context: .
+      dockerfile: config-server/Dockerfile
     container_name: config
     volumes:
       - ./config-repo:/config-repo
@@ -13,7 +15,9 @@ services:
       retries: 30
 
   discovery:
-    build: ./discovery-server
+    build:
+      context: .
+      dockerfile: discovery-server/Dockerfile
     container_name: discovery
     depends_on:
       config:
@@ -72,7 +76,9 @@ services:
       start_period: 20s
 
   pricing:
-    build: ./pricing-service
+    build:
+      context: .
+      dockerfile: pricing-service/Dockerfile
     container_name: pricing
     depends_on:
       config:
@@ -89,7 +95,9 @@ services:
       retries: 30
 
   reservation:
-    build: ./reservation-service
+    build:
+      context: .
+      dockerfile: reservation-service/Dockerfile
     container_name: reservation
     depends_on:
       config:
@@ -108,7 +116,9 @@ services:
       retries: 30
 
   client:
-    build: ./client-service
+    build:
+      context: .
+      dockerfile: client-service/Dockerfile
     container_name: client
     environment:
       DB_USERNAME: root
@@ -128,7 +138,9 @@ services:
       retries: 30
 
   gateway:
-    build: ./gateway-service
+    build:
+      context: .
+      dockerfile: gateway-service/Dockerfile
     container_name: gateway
     depends_on:
       config:

--- a/gateway-service/Dockerfile
+++ b/gateway-service/Dockerfile
@@ -1,12 +1,13 @@
 FROM maven:3.9.9-eclipse-temurin-17 AS build
 WORKDIR /app
-COPY pom.xml .
-COPY src ./src
+# Copia todo el proyecto para resolver el POM padre
+COPY . .
+WORKDIR /app/gateway-service
 RUN mvn clean package -DskipTests
 
 FROM eclipse-temurin:17-jre-alpine
 WORKDIR /app
-COPY --from=build /app/target/*.jar app.jar
+COPY --from=build /app/gateway-service/target/*.jar app.jar
 ENV JAVA_TOOL_OPTIONS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=60"
 EXPOSE 8080 9090
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/pricing-service/Dockerfile
+++ b/pricing-service/Dockerfile
@@ -1,12 +1,13 @@
 FROM maven:3.9.9-eclipse-temurin-17 AS build
 WORKDIR /app
-COPY pom.xml .
-COPY src ./src
+# Copia todo el proyecto para resolver el POM padre
+COPY . .
+WORKDIR /app/pricing-service
 RUN mvn -B package -DskipTests
 
 FROM eclipse-temurin:17-jre
 WORKDIR /app
-COPY --from=build /app/target/*.jar app.jar
+COPY --from=build /app/pricing-service/target/*.jar app.jar
 ENV JAVA_TOOL_OPTIONS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=60"
 EXPOSE 8080 9090
 ENTRYPOINT ["java","-jar","/app/app.jar"]

--- a/reservation-service/Dockerfile
+++ b/reservation-service/Dockerfile
@@ -1,12 +1,13 @@
 FROM maven:3.9.9-eclipse-temurin-17 AS build
 WORKDIR /app
-COPY pom.xml .
-COPY src ./src
+# Copia todo el proyecto para resolver el POM padre
+COPY . .
+WORKDIR /app/reservation-service
 RUN mvn -B package -DskipTests
 
 FROM eclipse-temurin:17-jre
 WORKDIR /app
-COPY --from=build /app/target/*.jar app.jar
+COPY --from=build /app/reservation-service/target/*.jar app.jar
 ENV JAVA_TOOL_OPTIONS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=60"
 EXPOSE 8080 9090
 ENTRYPOINT ["java","-jar","/app/app.jar"]


### PR DESCRIPTION
## Summary
- copy the whole repository when building each Java service so Maven can find the parent pom
- adjust paths in Dockerfiles
- build each service in docker-compose using the repo root as context

## Testing
- `mvn -DskipITs verify` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6843afab8a88832ca669460ba2822a03