### PR TITLE
Add Prometheus monitoring and secure DB credentials

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,2 @@
-DB_USERNAME=root
-DB_PASSWORD=password
+DB_USERNAME=karting
+DB_PASSWORD=kart1ng_pwd

--- a/client-service/Dockerfile
+++ b/client-service/Dockerfile
@@ -2,15 +2,16 @@
 FROM maven:3.9.9-eclipse-temurin-17 AS build
 WORKDIR /app
 
-# capa 1: dependencias
-COPY pom.xml .
+# capa 1 ─ SÓLO wrapper + pom
+COPY .mvn/ .mvn
+COPY mvnw pom.xml ./
 RUN --mount=type=cache,target=/root/.m2 \
-    mvn -B dependency:go-offline
+    ./mvnw -B dependency:go-offline
 
-# capa 2: codigo
+# capa 2 ─ resto del código
 COPY src src
 RUN --mount=type=cache,target=/root/.m2 \
-    mvn -B package -DskipTests
+    ./mvnw -B package -DskipTests
 
 FROM eclipse-temurin:17-jre-alpine
 WORKDIR /app

--- a/client-service/pom.xml
+++ b/client-service/pom.xml
@@ -56,6 +56,14 @@
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-config</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.retry</groupId>
+            <artifactId>spring-retry</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-aspects</artifactId>
+        </dependency>
 
         <!-- Eureka Client -->
         <dependency>
@@ -67,6 +75,10 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
         </dependency>
 
         <!-- Lombok -->

--- a/client-service/src/main/resources/application.properties
+++ b/client-service/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 server.port=0
 eureka.client.service-url.defaultZone=http://discovery:8761/eureka/
-management.endpoints.web.exposure.include=health,info
+management.endpoints.web.exposure.include=health,info,prometheus
 management.endpoint.health.show-details=always
 spring.jpa.hibernate.ddl-auto=update

--- a/config-repo/client-service.properties
+++ b/config-repo/client-service.properties
@@ -3,4 +3,6 @@ spring.datasource.username=${DB_USERNAME}
 spring.datasource.password=${DB_PASSWORD}
 spring.jpa.defer-datasource-initialization=true
 logging.level.org.springframework=INFO
+management.endpoints.web.exposure.include=health,info,prometheus
+management.metrics.tags.application=${spring.application.name}
 management.server.port=9090

--- a/config-repo/gateway-service.properties
+++ b/config-repo/gateway-service.properties
@@ -13,5 +13,6 @@ spring.cloud.gateway.routes[2].uri=lb://RESERVATION-SERVICE
 spring.cloud.gateway.routes[2].predicates[0]=Path=/api/reservations/**
 
 eureka.client.service-url.defaultZone=http://discovery:8761/eureka/
-management.endpoints.web.exposure.include=health,info
+management.endpoints.web.exposure.include=health,info,prometheus
+management.metrics.tags.application=${spring.application.name}
 management.endpoint.health.show-details=always

--- a/config-repo/pricing-service.properties
+++ b/config-repo/pricing-service.properties
@@ -1,12 +1,13 @@
 server.port=0
 spring.datasource.url=jdbc:mysql://pricing-db:3306/pricingdb?createDatabaseIfNotExist=true&serverTimezone=UTC
-spring.datasource.username=root
-spring.datasource.password=password
+spring.datasource.username=${DB_USERNAME}
+spring.datasource.password=${DB_PASSWORD}
 spring.sql.init.mode=always
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.defer-datasource-initialization=true
 spring.jpa.open-in-view=false
 logging.level.org.springframework=INFO
-management.endpoints.web.exposure.include=health,info
+management.endpoints.web.exposure.include=health,info,prometheus
+management.metrics.tags.application=${spring.application.name}
 management.endpoint.health.show-details=always
 management.server.port=9090

--- a/config-repo/reservation-service.properties
+++ b/config-repo/reservation-service.properties
@@ -1,10 +1,11 @@
 server.port=0
 spring.datasource.url=jdbc:mysql://reservation-db:3306/reservationdb?createDatabaseIfNotExist=true&serverTimezone=UTC
-spring.datasource.username=root
-spring.datasource.password=password
+spring.datasource.username=${DB_USERNAME}
+spring.datasource.password=${DB_PASSWORD}
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.open-in-view=false
 logging.level.org.springframework=INFO
-management.endpoints.web.exposure.include=health,info
+management.endpoints.web.exposure.include=health,info,prometheus
+management.metrics.tags.application=${spring.application.name}
 management.endpoint.health.show-details=always
 management.server.port=9090

--- a/config-server/Dockerfile
+++ b/config-server/Dockerfile
@@ -2,13 +2,14 @@
 FROM maven:3.9.9-eclipse-temurin-17 AS build
 WORKDIR /app
 
-COPY pom.xml .
+COPY .mvn/ .mvn
+COPY mvnw pom.xml ./
 RUN --mount=type=cache,target=/root/.m2 \
-    mvn -B dependency:go-offline
+    ./mvnw -B dependency:go-offline
 
 COPY src src
 RUN --mount=type=cache,target=/root/.m2 \
-    mvn -B package -DskipTests
+    ./mvnw -B package -DskipTests
 
 FROM eclipse-temurin:17-jre
 WORKDIR /app

--- a/config-server/pom.xml
+++ b/config-server/pom.xml
@@ -36,6 +36,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/config-server/src/main/resources/application.properties
+++ b/config-server/src/main/resources/application.properties
@@ -4,4 +4,5 @@ spring.application.name=config-server
 # Activamos almacenamiento nativo en una carpeta
 spring.profiles.active=native
 spring.cloud.config.server.native.search-locations=file:///config-repo
-management.endpoints.web.exposure.include=health,info
+management.endpoints.web.exposure.include=health,info,prometheus
+management.metrics.tags.application=${spring.application.name}

--- a/discovery-server/Dockerfile
+++ b/discovery-server/Dockerfile
@@ -2,13 +2,14 @@
 FROM maven:3.9.9-eclipse-temurin-17 AS build
 WORKDIR /app
 
-COPY pom.xml .
+COPY .mvn/ .mvn
+COPY mvnw pom.xml ./
 RUN --mount=type=cache,target=/root/.m2 \
-    mvn -B dependency:go-offline
+    ./mvnw -B dependency:go-offline
 
 COPY src src
 RUN --mount=type=cache,target=/root/.m2 \
-    mvn -B package -DskipTests
+    ./mvnw -B package -DskipTests
 
 FROM eclipse-temurin:17-jre
 WORKDIR /app

--- a/discovery-server/pom.xml
+++ b/discovery-server/pom.xml
@@ -36,6 +36,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/discovery-server/src/main/resources/application.properties
+++ b/discovery-server/src/main/resources/application.properties
@@ -5,7 +5,8 @@ server.port=8761
 
 # Puerto del Actuator (opcional, separado)
 management.server.port=8081
-management.endpoints.web.exposure.include=health,info
+management.endpoints.web.exposure.include=health,info,prometheus
+management.metrics.tags.application=${spring.application.name}
 management.endpoint.health.show-details=always
 
 # Eureka standalone: no se registra en otros peers

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,13 +29,16 @@ services:
   pricing-db:
     image: mysql:8.0.33
     container_name: pricing-db
+    env_file: .env
     environment:
-      MYSQL_ROOT_PASSWORD: password
       MYSQL_DATABASE: pricingdb
+      MYSQL_USER: ${DB_USERNAME}
+      MYSQL_PASSWORD: ${DB_PASSWORD}
+      MYSQL_ROOT_PASSWORD: root_pwd
     volumes:
       - pricing-data:/var/lib/mysql
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-ppassword"]
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-proot_pwd"]
       interval: 10s
       timeout: 5s
       retries: 10
@@ -44,13 +47,16 @@ services:
   reservation-db:
     image: mysql:8.0.33
     container_name: reservation-db
+    env_file: .env
     environment:
-      MYSQL_ROOT_PASSWORD: password
       MYSQL_DATABASE: reservationdb
+      MYSQL_USER: ${DB_USERNAME}
+      MYSQL_PASSWORD: ${DB_PASSWORD}
+      MYSQL_ROOT_PASSWORD: root_pwd
     volumes:
       - reservation-data:/var/lib/mysql
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-ppassword"]
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-proot_pwd"]
       interval: 10s
       timeout: 5s
       retries: 10
@@ -59,13 +65,16 @@ services:
   client-db:
     image: mysql:8.0.33
     container_name: client-db
+    env_file: .env
     environment:
-      MYSQL_ROOT_PASSWORD: password
       MYSQL_DATABASE: clientsdb
+      MYSQL_USER: ${DB_USERNAME}
+      MYSQL_PASSWORD: ${DB_PASSWORD}
+      MYSQL_ROOT_PASSWORD: root_pwd
     volumes:
       - client-data:/var/lib/mysql
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-ppassword"]
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-proot_pwd"]
       interval: 10s
       timeout: 5s
       retries: 10
@@ -74,6 +83,7 @@ services:
   pricing:
     build: pricing-service
     container_name: pricing
+    env_file: .env
     depends_on:
       config:
         condition: service_healthy
@@ -91,6 +101,7 @@ services:
   reservation:
     build: reservation-service
     container_name: reservation
+    env_file: .env
     depends_on:
       config:
         condition: service_healthy
@@ -128,6 +139,7 @@ services:
   gateway:
     build: gateway-service
     container_name: gateway
+    env_file: .env
     depends_on:
       config:
         condition: service_healthy
@@ -137,7 +149,7 @@ services:
       - "8080:8080"
     restart: on-failure
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:9090/actuator/health"]
       interval: 10s
       timeout: 5s
       retries: 30
@@ -149,6 +161,14 @@ services:
       - "5173:80"
     depends_on:
       - gateway
+
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    ports: ["9091:9090"]
+    volumes:
+      - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml
+    restart: unless-stopped
 
 volumes:
   pricing-data:

--- a/gateway-service/Dockerfile
+++ b/gateway-service/Dockerfile
@@ -2,13 +2,14 @@
 FROM maven:3.9.9-eclipse-temurin-17 AS build
 WORKDIR /app
 
-COPY pom.xml .
+COPY .mvn/ .mvn
+COPY mvnw pom.xml ./
 RUN --mount=type=cache,target=/root/.m2 \
-    mvn -B dependency:go-offline
+    ./mvnw -B dependency:go-offline
 
 COPY src src
 RUN --mount=type=cache,target=/root/.m2 \
-    mvn -B package -DskipTests
+    ./mvnw -B package -DskipTests
 
 FROM eclipse-temurin:17-jre-alpine
 WORKDIR /app

--- a/gateway-service/pom.xml
+++ b/gateway-service/pom.xml
@@ -44,8 +44,20 @@
             <artifactId>spring-cloud-starter-config</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.retry</groupId>
+            <artifactId>spring-retry</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-aspects</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,0 +1,9 @@
+scrape_configs:
+  - job_name: 'spring'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets:
+          - 'pricing:9090'
+          - 'reservation:9090'
+          - 'client:9090'
+          - 'gateway:9090'

--- a/pricing-service/Dockerfile
+++ b/pricing-service/Dockerfile
@@ -2,13 +2,14 @@
 FROM maven:3.9.9-eclipse-temurin-17 AS build
 WORKDIR /app
 
-COPY pom.xml .
+COPY .mvn/ .mvn
+COPY mvnw pom.xml ./
 RUN --mount=type=cache,target=/root/.m2 \
-    mvn -B dependency:go-offline
+    ./mvnw -B dependency:go-offline
 
 COPY src src
 RUN --mount=type=cache,target=/root/.m2 \
-    mvn -B package -DskipTests
+    ./mvnw -B package -DskipTests
 
 FROM eclipse-temurin:17-jre
 WORKDIR /app

--- a/pricing-service/pom.xml
+++ b/pricing-service/pom.xml
@@ -63,6 +63,10 @@
                         <groupId>org.springframework.boot</groupId>
                         <artifactId>spring-boot-starter-actuator</artifactId>
                 </dependency>
+                <dependency>
+                        <groupId>io.micrometer</groupId>
+                        <artifactId>micrometer-registry-prometheus</artifactId>
+                </dependency>
 
 		<!-- Lombok (procesador de anotaciones) -->
                 <dependency>
@@ -79,6 +83,14 @@
                 <dependency>
                         <groupId>org.springframework.cloud</groupId>
                         <artifactId>spring-cloud-starter-config</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>org.springframework.retry</groupId>
+                        <artifactId>spring-retry</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>org.springframework</groupId>
+                        <artifactId>spring-aspects</artifactId>
                 </dependency>
 
 		<!-- Tests -->

--- a/pricing-service/src/main/resources/application.properties
+++ b/pricing-service/src/main/resources/application.properties
@@ -9,5 +9,5 @@ spring.cloud.config.fail-fast=true
 # Eureka
 eureka.client.service-url.defaultZone=http://discovery:8761/eureka/
 
-management.endpoints.web.exposure.include=health,info
+management.endpoints.web.exposure.include=health,info,prometheus
 management.endpoint.health.show-details=always

--- a/reservation-service/Dockerfile
+++ b/reservation-service/Dockerfile
@@ -2,13 +2,14 @@
 FROM maven:3.9.9-eclipse-temurin-17 AS build
 WORKDIR /app
 
-COPY pom.xml .
+COPY .mvn/ .mvn
+COPY mvnw pom.xml ./
 RUN --mount=type=cache,target=/root/.m2 \
-    mvn -B dependency:go-offline
+    ./mvnw -B dependency:go-offline
 
 COPY src src
 RUN --mount=type=cache,target=/root/.m2 \
-    mvn -B package -DskipTests
+    ./mvnw -B package -DskipTests
 
 FROM eclipse-temurin:17-jre
 WORKDIR /app

--- a/reservation-service/pom.xml
+++ b/reservation-service/pom.xml
@@ -63,6 +63,10 @@
                         <groupId>org.springframework.boot</groupId>
                         <artifactId>spring-boot-starter-actuator</artifactId>
                 </dependency>
+                <dependency>
+                        <groupId>io.micrometer</groupId>
+                        <artifactId>micrometer-registry-prometheus</artifactId>
+                </dependency>
 
 		<!-- Lombok (procesador de anotaciones) -->
                 <dependency>
@@ -79,6 +83,14 @@
                 <dependency>
                         <groupId>org.springframework.cloud</groupId>
                         <artifactId>spring-cloud-starter-config</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>org.springframework.retry</groupId>
+                        <artifactId>spring-retry</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>org.springframework</groupId>
+                        <artifactId>spring-aspects</artifactId>
                 </dependency>
 
 		<!-- Tests -->

--- a/reservation-service/src/main/resources/application.properties
+++ b/reservation-service/src/main/resources/application.properties
@@ -7,5 +7,5 @@ spring.cloud.config.retry.max-attempts=10
 spring.cloud.config.fail-fast=true
 
 eureka.client.service-url.defaultZone=http://discovery:8761/eureka/
-management.endpoints.web.exposure.include=health,info
+management.endpoints.web.exposure.include=health,info,prometheus
 management.endpoint.health.show-details=always


### PR DESCRIPTION
## Summary
- configure Maven wrapper caching for all Dockerfiles
- update MySQL credentials with global `.env`
- expose Prometheus metrics in Spring services
- add Prometheus service to `docker-compose`
- unify gateway health check and use `.env` in every service

## Testing
- `sh pricing-service/mvnw -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6843b866b374832ca4d9da433f9a1190