### PR TITLE
Standardize base images and expose management port

### DIFF
--- a/client-service/Dockerfile
+++ b/client-service/Dockerfile
@@ -13,7 +13,7 @@ COPY src src
 RUN --mount=type=cache,target=/root/.m2,sharing=locked \
     ./mvnw -B package -DskipTests
 
-FROM eclipse-temurin:17-jre-alpine
+FROM eclipse-temurin:17-jre
 WORKDIR /app
 COPY --from=build /app/target/*.jar app.jar
 ENV JAVA_TOOL_OPTIONS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=60 -XX:+UseSerialGC"

--- a/config-server/src/main/resources/application.properties
+++ b/config-server/src/main/resources/application.properties
@@ -6,3 +6,4 @@ spring.profiles.active=native
 spring.cloud.config.server.native.search-locations=file:///config-repo
 management.endpoints.web.exposure.include=health,info,prometheus
 management.metrics.tags.application=${spring.application.name}
+management.server.port=9090

--- a/gateway-service/Dockerfile
+++ b/gateway-service/Dockerfile
@@ -11,7 +11,7 @@ COPY src src
 RUN --mount=type=cache,target=/root/.m2,sharing=locked \
     ./mvnw -B package -DskipTests
 
-FROM eclipse-temurin:17-jre-alpine
+FROM eclipse-temurin:17-jre
 WORKDIR /app
 COPY --from=build /app/target/*.jar app.jar
 ENV JAVA_TOOL_OPTIONS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=60 -XX:+UseSerialGC"

--- a/kartingrm-frontend/Dockerfile
+++ b/kartingrm-frontend/Dockerfile
@@ -7,7 +7,7 @@ COPY . .
 RUN npm run build
 
 # Stage 2: Servir con Nginx
-FROM nginx:alpine
+FROM nginx:stable
 COPY --from=build /app/dist /usr/share/nginx/html
 EXPOSE 80
 ENTRYPOINT ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## Summary
- add `management.server.port=9090` in `config-server`
- use Debian-based JRE images for all services
- switch frontend runtime to `nginx:stable`

## Testing
- `./client-service/mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6844373805e8832c895370974abf61ca