### PR TITLE
Fix Docker build and health check

### DIFF
--- a/config-server/Dockerfile
+++ b/config-server/Dockerfile
@@ -2,14 +2,13 @@
 FROM maven:3.9.9-eclipse-temurin-17 AS build
 WORKDIR /app
 
-COPY .mvn/ .mvn
-COPY mvnw pom.xml ./
+COPY pom.xml .
 RUN --mount=type=cache,target=/root/.m2,sharing=locked \
-    ./mvnw -B dependency:go-offline
+    mvn -B dependency:go-offline
 
 COPY src src
 RUN --mount=type=cache,target=/root/.m2,sharing=locked \
-    ./mvnw -B package -DskipTests
+    mvn -B package -DskipTests
 
 FROM eclipse-temurin:17-jre
 WORKDIR /app

--- a/discovery-server/Dockerfile
+++ b/discovery-server/Dockerfile
@@ -2,14 +2,13 @@
 FROM maven:3.9.9-eclipse-temurin-17 AS build
 WORKDIR /app
 
-COPY .mvn/ .mvn
-COPY mvnw pom.xml ./
+COPY pom.xml .
 RUN --mount=type=cache,target=/root/.m2,sharing=locked \
-    ./mvnw -B dependency:go-offline
+    mvn -B dependency:go-offline
 
 COPY src src
 RUN --mount=type=cache,target=/root/.m2,sharing=locked \
-    ./mvnw -B package -DskipTests
+    mvn -B package -DskipTests
 
 FROM eclipse-temurin:17-jre
 WORKDIR /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     ports:
       - "8888:8888"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8888/actuator/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:9090/actuator/health"]
       interval: 10s
       timeout: 5s
       retries: 30


### PR DESCRIPTION
## Summary
- adjust Dockerfiles for `config-server` and `discovery-server`
- fix config server healthcheck port

## Testing
- `mvn -q -DskipTests install` *(fails: `mvn: command not found`)*
- `docker compose version` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6845008bc188832cada24b6ca1f5cefb