### PR TITLE
Fix COPY comments in Dockerfiles

### DIFF
--- a/client-service/Dockerfile
+++ b/client-service/Dockerfile
@@ -3,7 +3,7 @@ FROM maven:3.9.9-eclipse-temurin-17 AS build
 WORKDIR /app
 
 # ---------- 1. pom.xml para caché ----------
-COPY pom.xml .                       # raíz
+COPY pom.xml .
 COPY config-server/pom.xml         config-server/
 COPY discovery-server/pom.xml      discovery-server/
 COPY gateway-service/pom.xml       gateway-service/

--- a/config-server/Dockerfile
+++ b/config-server/Dockerfile
@@ -3,7 +3,7 @@ FROM maven:3.9.9-eclipse-temurin-17 AS build
 WORKDIR /app
 
 # ---------- 1. pom.xml para caché ----------
-COPY pom.xml .                       # raíz
+COPY pom.xml .
 COPY config-server/pom.xml         config-server/
 COPY discovery-server/pom.xml      discovery-server/
 COPY gateway-service/pom.xml       gateway-service/

--- a/discovery-server/Dockerfile
+++ b/discovery-server/Dockerfile
@@ -3,7 +3,7 @@ FROM maven:3.9.9-eclipse-temurin-17 AS build
 WORKDIR /app
 
 # ---------- 1. pom.xml para caché ----------
-COPY pom.xml .                       # raíz
+COPY pom.xml .
 COPY config-server/pom.xml         config-server/
 COPY discovery-server/pom.xml      discovery-server/
 COPY gateway-service/pom.xml       gateway-service/

--- a/gateway-service/Dockerfile
+++ b/gateway-service/Dockerfile
@@ -3,7 +3,7 @@ FROM maven:3.9.9-eclipse-temurin-17 AS build
 WORKDIR /app
 
 # ---------- 1. pom.xml para caché ----------
-COPY pom.xml .                       # raíz
+COPY pom.xml .
 COPY config-server/pom.xml         config-server/
 COPY discovery-server/pom.xml      discovery-server/
 COPY gateway-service/pom.xml       gateway-service/

--- a/pricing-service/Dockerfile
+++ b/pricing-service/Dockerfile
@@ -3,7 +3,7 @@ FROM maven:3.9.9-eclipse-temurin-17 AS build
 WORKDIR /app
 
 # ---------- 1. pom.xml para caché ----------
-COPY pom.xml .                       # raíz
+COPY pom.xml .
 COPY config-server/pom.xml         config-server/
 COPY discovery-server/pom.xml      discovery-server/
 COPY gateway-service/pom.xml       gateway-service/

--- a/reservation-service/Dockerfile
+++ b/reservation-service/Dockerfile
@@ -3,7 +3,7 @@ FROM maven:3.9.9-eclipse-temurin-17 AS build
 WORKDIR /app
 
 # ---------- 1. pom.xml para caché ----------
-COPY pom.xml .                       # raíz
+COPY pom.xml .
 COPY config-server/pom.xml         config-server/
 COPY discovery-server/pom.xml      discovery-server/
 COPY gateway-service/pom.xml       gateway-service/


### PR DESCRIPTION
## Summary
- remove inline comments from COPY instructions in Dockerfiles

## Testing
- `docker compose config` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_68463254ead8832c8b31f6ae1782316b