### PR TITLE
Fix Config Client setup

### DIFF
--- a/client-service/src/main/resources/application.properties
+++ b/client-service/src/main/resources/application.properties
@@ -1,4 +1,12 @@
 server.port=0
+spring.application.name=client-service
+# Config Client
+spring.config.import=configserver:http://config:8888
+spring.cloud.config.fail-fast=true
+spring.cloud.config.retry.initial-interval=1000
+spring.cloud.config.retry.multiplier=1.5
+spring.cloud.config.retry.max-interval=20000
+spring.cloud.config.retry.max-attempts=6
 eureka.client.service-url.defaultZone=http://discovery:8761/eureka/
 management.endpoints.web.exposure.include=health,info,prometheus
 management.endpoint.health.show-details=when_authorized

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,6 +96,12 @@ services:
         MODULE_NAME: pricing-service
     container_name: pricing
     env_file: .env
+    environment:
+      - SPRING_CONFIG_IMPORT=configserver:http://config:8888
+      - SPRING_CLOUD_CONFIG_RETRY_INITIAL_INTERVAL=1000
+      - SPRING_CLOUD_CONFIG_RETRY_MULTIPLIER=1.5
+      - SPRING_CLOUD_CONFIG_RETRY_MAX_INTERVAL=20000
+      - SPRING_CLOUD_CONFIG_RETRY_MAX_ATTEMPTS=6
     depends_on:
       config:
         condition: service_healthy
@@ -118,6 +124,12 @@ services:
         MODULE_NAME: reservation-service
     container_name: reservation
     env_file: .env
+    environment:
+      - SPRING_CONFIG_IMPORT=configserver:http://config:8888
+      - SPRING_CLOUD_CONFIG_RETRY_INITIAL_INTERVAL=1000
+      - SPRING_CLOUD_CONFIG_RETRY_MULTIPLIER=1.5
+      - SPRING_CLOUD_CONFIG_RETRY_MAX_INTERVAL=20000
+      - SPRING_CLOUD_CONFIG_RETRY_MAX_ATTEMPTS=6
     depends_on:
       config:
         condition: service_healthy
@@ -142,6 +154,12 @@ services:
         MODULE_NAME: client-service
     container_name: client
     env_file: .env
+    environment:
+      - SPRING_CONFIG_IMPORT=configserver:http://config:8888
+      - SPRING_CLOUD_CONFIG_RETRY_INITIAL_INTERVAL=1000
+      - SPRING_CLOUD_CONFIG_RETRY_MULTIPLIER=1.5
+      - SPRING_CLOUD_CONFIG_RETRY_MAX_INTERVAL=20000
+      - SPRING_CLOUD_CONFIG_RETRY_MAX_ATTEMPTS=6
     depends_on:
       config:
         condition: service_healthy
@@ -164,6 +182,12 @@ services:
         MODULE_NAME: gateway-service
     container_name: gateway
     env_file: .env
+    environment:
+      - SPRING_CONFIG_IMPORT=configserver:http://config:8888
+      - SPRING_CLOUD_CONFIG_RETRY_INITIAL_INTERVAL=1000
+      - SPRING_CLOUD_CONFIG_RETRY_MULTIPLIER=1.5
+      - SPRING_CLOUD_CONFIG_RETRY_MAX_INTERVAL=20000
+      - SPRING_CLOUD_CONFIG_RETRY_MAX_ATTEMPTS=6
     depends_on:
       config:
         condition: service_healthy

--- a/gateway-service/src/main/resources/application.properties
+++ b/gateway-service/src/main/resources/application.properties
@@ -1,13 +1,12 @@
-spring.application.name=reservation-service
-
+server.port=0
+spring.application.name=gateway-service
 # Config Client
 spring.config.import=configserver:http://config:8888
+spring.cloud.config.fail-fast=true
 spring.cloud.config.retry.initial-interval=1000
 spring.cloud.config.retry.multiplier=1.5
 spring.cloud.config.retry.max-interval=20000
 spring.cloud.config.retry.max-attempts=6
-spring.cloud.config.fail-fast=true
-
 eureka.client.service-url.defaultZone=http://discovery:8761/eureka/
 management.endpoints.web.exposure.include=health,info,prometheus
 management.endpoint.health.show-details=when_authorized

--- a/pricing-service/src/main/resources/application.properties
+++ b/pricing-service/src/main/resources/application.properties
@@ -1,9 +1,11 @@
 spring.application.name=pricing-service
 
 # Config Client
-spring.config.import=optional:configserver:http://config:8888
-spring.cloud.config.retry.initial-interval=2000
-spring.cloud.config.retry.max-attempts=10
+spring.config.import=configserver:http://config:8888
+spring.cloud.config.retry.initial-interval=1000
+spring.cloud.config.retry.multiplier=1.5
+spring.cloud.config.retry.max-interval=20000
+spring.cloud.config.retry.max-attempts=6
 spring.cloud.config.fail-fast=true
 
 # Eureka


### PR DESCRIPTION
## Summary
- add spring.config.import and config retry to Client, Pricing, Gateway, Reservation services
- create default application.properties for gateway service
- export Config Server configuration via environment variables in docker-compose

## Testing
- `./mvnw -q -DskipTests package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_684659a38294832cb207250677829f37