### PR TITLE
Add session-service module

### DIFF
--- a/config-repo/gateway-service.properties
+++ b/config-repo/gateway-service.properties
@@ -12,6 +12,10 @@ spring.cloud.gateway.routes[2].id=reservation-route
 spring.cloud.gateway.routes[2].uri=lb://RESERVATION-SERVICE
 spring.cloud.gateway.routes[2].predicates[0]=Path=/api/reservations/**
 
+spring.cloud.gateway.routes[3].id=session-route
+spring.cloud.gateway.routes[3].uri=lb://SESSION-SERVICE
+spring.cloud.gateway.routes[3].predicates[0]=Path=/api/sessions/**
+
 eureka.client.service-url.defaultZone=http://discovery:8761/eureka/
 management.endpoints.web.exposure.include=health,info,prometheus
 management.metrics.tags.application=${spring.application.name}

--- a/config-repo/session-service.properties
+++ b/config-repo/session-service.properties
@@ -1,0 +1,16 @@
+spring.datasource.url=jdbc:mysql://session-db:3306/sessiondb?createDatabaseIfNotExist=true&serverTimezone=UTC
+spring.datasource.username=${DB_USERNAME}
+spring.datasource.password=${DB_PASSWORD}
+
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.open-in-view=false
+server.port=0
+
+spring.application.name=session-service
+eureka.client.service-url.defaultZone=http://discovery:8761/eureka/
+
+management.server.port=9090
+management.endpoints.web.exposure.include=health,info,prometheus
+management.metrics.tags.application=${spring.application.name}
+management.tracing.sampling.probability=1.0
+management.zipkin.tracing.endpoint=http://zipkin:9411/api/v2/spans

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,6 +88,25 @@ services:
       retries: 10
       start_period: 20s
 
+  # MySQL de sesiones
+  session-db:
+    image: mysql:8.0.33
+    container_name: session-db
+    env_file: .env
+    environment:
+      MYSQL_DATABASE: sessiondb
+      MYSQL_USER: ${DB_USERNAME}
+      MYSQL_PASSWORD: ${DB_PASSWORD}
+      MYSQL_ROOT_PASSWORD: root_pwd
+    volumes:
+      - session-data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-proot_pwd"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 20s
+
   pricing:
     build:
       context: .
@@ -174,6 +193,31 @@ services:
       timeout: 5s
       retries: 30
 
+  # microservicio sesiones
+  session:
+    build:
+      context: .
+      dockerfile: session-service/Dockerfile
+      args: { MODULE_NAME: session-service }
+    container_name: session
+    env_file: .env
+    environment:
+      - SPRING_CONFIG_IMPORT=configserver:http://config:8888
+      - SPRING_CLOUD_CONFIG_RETRY_INITIAL_INTERVAL=1000
+      - SPRING_CLOUD_CONFIG_RETRY_MULTIPLIER=1.5
+      - SPRING_CLOUD_CONFIG_RETRY_MAX_INTERVAL=20000
+      - SPRING_CLOUD_CONFIG_RETRY_MAX_ATTEMPTS=6
+    depends_on:
+      config: { condition: service_healthy }
+      discovery: { condition: service_healthy }
+      session-db: { condition: service_healthy }
+    restart: on-failure
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9090/actuator/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+
   gateway:
     build:
       context: .
@@ -228,3 +272,4 @@ volumes:
   pricing-data:
   reservation-data:
   client-data:
+  session-data:

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -6,6 +6,7 @@ scrape_configs:
           - 'pricing:9090'
           - 'reservation:9090'
           - 'client:9090'
+          - 'session:9090'
           - 'gateway:9090'
           - 'config:9090'
           - 'discovery:9090'

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
         <module>client-service</module>
         <module>pricing-service</module>
         <module>reservation-service</module>
+        <module>session-service</module>
     </modules>
 
     <dependencyManagement>

--- a/session-service/Dockerfile
+++ b/session-service/Dockerfile
@@ -1,0 +1,32 @@
+# syntax=docker/dockerfile:1.5
+FROM maven:3.9.9-eclipse-temurin-17 AS build
+WORKDIR /app
+
+# ---------- 1. pom.xml para caché ----------
+COPY pom.xml .
+COPY config-server/pom.xml         config-server/
+COPY discovery-server/pom.xml      discovery-server/
+COPY gateway-service/pom.xml       gateway-service/
+COPY client-service/pom.xml        client-service/
+COPY pricing-service/pom.xml       pricing-service/
+COPY reservation-service/pom.xml   reservation-service/
+COPY session-service/pom.xml       session-service/
+
+RUN --mount=type=cache,target=/root/.m2,sharing=locked \
+    mvn -B -q dependency:go-offline
+
+# ---------- 2. código fuente ----------
+COPY . .
+
+ARG MODULE_NAME
+RUN --mount=type=cache,target=/root/.m2,sharing=locked \
+    mvn -B -q -pl ${MODULE_NAME} -am clean package -DskipTests -Dmaven.test.skip=true
+
+# ---------- 3. imagen final ----------
+FROM eclipse-temurin:17-jre
+WORKDIR /app
+ARG MODULE_NAME
+COPY --from=build /app/${MODULE_NAME}/target/${MODULE_NAME}-*.jar app.jar
+ENV JAVA_TOOL_OPTIONS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=60 -XX:+UseSerialGC"
+EXPOSE 9090
+ENTRYPOINT ["java","-jar","app.jar"]

--- a/session-service/pom.xml
+++ b/session-service/pom.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>cl.kartingrm</groupId>
+        <artifactId>kartingrm-parent</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>session-service</artifactId>
+    <name>session-service</name>
+    <description>Servicio de sesiones</description>
+
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+
+    <dependencies>
+        <!-- Web -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <!-- JPA + MySQL -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <!-- Config Client -->
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.retry</groupId>
+            <artifactId>spring-retry</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-aspects</artifactId>
+        </dependency>
+
+        <!-- Eureka Client -->
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
+        </dependency>
+
+        <!-- Actuator -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-tracing-bridge-brave</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.zipkin.reporter2</groupId>
+            <artifactId>zipkin-reporter-brave</artifactId>
+        </dependency>
+
+        <!-- Lombok -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Tests -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/session-service/src/main/java/cl/kartingrm/session_service/SessionServiceApplication.java
+++ b/session-service/src/main/java/cl/kartingrm/session_service/SessionServiceApplication.java
@@ -1,0 +1,11 @@
+package cl.kartingrm.session_service;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class SessionServiceApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(SessionServiceApplication.class, args);
+    }
+}

--- a/session-service/src/main/java/cl/kartingrm/session_service/controller/SessionController.java
+++ b/session-service/src/main/java/cl/kartingrm/session_service/controller/SessionController.java
@@ -1,0 +1,38 @@
+package cl.kartingrm.session_service.controller;
+
+import cl.kartingrm.session_service.model.Session;
+import cl.kartingrm.session_service.service.SessionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.time.DayOfWeek;
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/sessions")
+@RequiredArgsConstructor
+public class SessionController {
+
+    private final SessionService s;
+
+    @GetMapping
+    public List<Session> all() { return s.all(); }
+
+    @PostMapping
+    public Session save(@RequestBody Session x) { return s.save(x); }
+
+    /** Registro de participantes tras crear una reserva */
+    @PutMapping("/{id}/register")
+    public void add(@PathVariable Long id, @RequestParam int n){
+        s.register(id,n);
+    }
+
+    /** Disponibilidad semanal usada por el frontend */
+    @GetMapping("/availability")
+    public Map<DayOfWeek, List<Session>> week(@RequestParam LocalDate from,
+                                             @RequestParam LocalDate to){
+        return s.week(from,to);
+    }
+}

--- a/session-service/src/main/java/cl/kartingrm/session_service/model/Session.java
+++ b/session-service/src/main/java/cl/kartingrm/session_service/model/Session.java
@@ -1,0 +1,41 @@
+package cl.kartingrm.session_service.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Entity
+@Table(name = "sessions",
+       uniqueConstraints = @UniqueConstraint(columnNames = {"session_date","start_time","end_time"}))
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Session {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "session_date", nullable = false)
+    private LocalDate sessionDate;
+
+    @Column(name = "start_time", nullable = false)
+    private LocalTime startTime;
+
+    @Column(name = "end_time", nullable = false)
+    private LocalTime endTime;
+
+    private Integer capacity;
+
+    /** Inscritos actuales */
+    private Integer participants = 0;
+
+    /** evita negativos / overflow */
+    public void addParticipants(int n) {
+        this.participants = Math.min(capacity, this.participants + n);
+    }
+}

--- a/session-service/src/main/java/cl/kartingrm/session_service/repository/SessionRepository.java
+++ b/session-service/src/main/java/cl/kartingrm/session_service/repository/SessionRepository.java
@@ -1,0 +1,11 @@
+package cl.kartingrm.session_service.repository;
+
+import cl.kartingrm.session_service.model.Session;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface SessionRepository extends JpaRepository<Session, Long> {
+    List<Session> findBySessionDateBetween(LocalDate from, LocalDate to);
+}

--- a/session-service/src/main/java/cl/kartingrm/session_service/service/SessionService.java
+++ b/session-service/src/main/java/cl/kartingrm/session_service/service/SessionService.java
@@ -1,0 +1,41 @@
+package cl.kartingrm.session_service.service;
+
+import cl.kartingrm.session_service.model.Session;
+import cl.kartingrm.session_service.repository.SessionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class SessionService {
+
+    private final SessionRepository repo;
+
+    @Transactional(readOnly = true)
+    public List<Session> all() { return repo.findAll(); }
+
+    @Transactional
+    public Session save(Session s) { return repo.save(s); }
+
+    @Transactional
+    public void register(Long id, int n) {
+        Session s = repo.findById(id)
+                        .orElseThrow(() -> new NoSuchElementException("session " + id));
+        s.addParticipants(n);
+        // dirty-checking JPA ⇒ no repo.save()
+    }
+
+    @Transactional(readOnly = true)
+    public Map<DayOfWeek, List<Session>> week(LocalDate from, LocalDate to) {
+        return repo.findBySessionDateBetween(from, to).stream()
+                   .collect(Collectors.groupingBy(
+                       sess -> sess.getSessionDate().getDayOfWeek(),
+                       TreeMap::new, Collectors.toList()));
+    }
+}

--- a/session-service/src/main/resources/application.properties
+++ b/session-service/src/main/resources/application.properties
@@ -1,0 +1,13 @@
+server.port=0
+spring.application.name=session-service
+
+spring.config.import=configserver:http://config:8888
+spring.cloud.config.fail-fast=true
+spring.cloud.config.retry.initial-interval=1000
+spring.cloud.config.retry.multiplier=1.5
+spring.cloud.config.retry.max-interval=20000
+spring.cloud.config.retry.max-attempts=6
+eureka.client.service-url.defaultZone=http://discovery:8761/eureka/
+management.endpoints.web.exposure.include=health,info,prometheus
+management.endpoint.health.show-details=when_authorized
+spring.jpa.hibernate.ddl-auto=update

--- a/session-service/src/test/java/cl/kartingrm/session_service/SessionServiceApplicationTests.java
+++ b/session-service/src/test/java/cl/kartingrm/session_service/SessionServiceApplicationTests.java
@@ -1,0 +1,13 @@
+package cl.kartingrm.session_service;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class SessionServiceApplicationTests {
+    @Test
+    void contextLoads() {
+    }
+}

--- a/session-service/src/test/java/cl/kartingrm/session_service/SessionServiceTest.java
+++ b/session-service/src/test/java/cl/kartingrm/session_service/SessionServiceTest.java
@@ -1,0 +1,30 @@
+package cl.kartingrm.session_service;
+
+import cl.kartingrm.session_service.model.Session;
+import cl.kartingrm.session_service.service.SessionService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class SessionServiceTest {
+    @Autowired SessionService svc;
+
+    @Test
+    void register_caps_limit() {
+        Session s = svc.save(Session.builder()
+                .sessionDate(LocalDate.now())
+                .startTime(LocalTime.of(14,0))
+                .endTime(LocalTime.of(14,15))
+                .capacity(10).build());
+        svc.register(s.getId(), 12);
+        assertThat(svc.all().get(0).getParticipants()).isEqualTo(10);
+    }
+}

--- a/session-service/src/test/resources/application-test.properties
+++ b/session-service/src/test/resources/application-test.properties
@@ -1,0 +1,3 @@
+spring.config.import=
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.jpa.hibernate.ddl-auto=update


### PR DESCRIPTION
## Summary
- introduce new `session-service` module with controllers, JPA entity and tests
- expose configuration for the new service in `config-repo`
- register session routes in API gateway
- extend Docker compose and monitoring for new service
- update parent pom modules

## Testing
- `./mvnw -q -pl session-service test` *(fails: Non-resolvable parent POM)*
- `docker build -f session-service/Dockerfile --build-arg MODULE_NAME=session-service .` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6847242e1520832c9e14a1ba600118ee