### PR TITLE
Fix session update when creating reservation

### DIFF
--- a/reservation-service/src/main/java/cl/kartingrm/reservation_service/dto/CreateReservationRequest.java
+++ b/reservation-service/src/main/java/cl/kartingrm/reservation_service/dto/CreateReservationRequest.java
@@ -3,6 +3,7 @@ package cl.kartingrm.reservation_service.dto;
 import java.time.LocalDate;
 
 public record CreateReservationRequest(
+        Long sessionId,
         int laps,
         int participants,
         String clientEmail,

--- a/reservation-service/src/main/java/cl/kartingrm/reservation_service/model/Reservation.java
+++ b/reservation-service/src/main/java/cl/kartingrm/reservation_service/model/Reservation.java
@@ -12,6 +12,7 @@ public class Reservation {
 
     private int laps;
     private int participants;
+    private Long sessionId;
     private String clientEmail;
 
     private int basePrice;

--- a/reservation-service/src/main/java/cl/kartingrm/reservation_service/service/ReservationPersister.java
+++ b/reservation-service/src/main/java/cl/kartingrm/reservation_service/service/ReservationPersister.java
@@ -20,6 +20,7 @@ public class ReservationPersister {
         Reservation r = Reservation.builder()
                 .laps(req.laps())
                 .participants(req.participants())
+                .sessionId(req.sessionId())
                 .clientEmail(req.clientEmail())
                 .basePrice((int) (p.baseUnit() * req.participants()))
                 .discountPercent((int) p.totalDiscountPct())

--- a/reservation-service/src/main/java/cl/kartingrm/reservation_service/service/ReservationService.java
+++ b/reservation-service/src/main/java/cl/kartingrm/reservation_service/service/ReservationService.java
@@ -39,7 +39,7 @@ public class ReservationService {
                 .block();
 
         web.put()
-                .uri(SESSION_URL + "/api/sessions/{id}/register?n={n}", saved.getId(), req.participants())
+                .uri(SESSION_URL + "/api/sessions/{id}/register?n={n}", req.sessionId(), req.participants())
                 .retrieve()
                 .toBodilessEntity()
                 .retry(3)


### PR DESCRIPTION
## Summary
- include `sessionId` in reservation creation DTO
- persist the session id in reservations
- use the proper session id when updating participants

## Testing
- `./mvnw -o -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68473b1113c8832cbd7b632cd489c12d