### PR TITLE
Add Kubernetes manifests and update service configs

### DIFF
--- a/config-repo/pricing-service.properties
+++ b/config-repo/pricing-service.properties
@@ -1,4 +1,4 @@
-server.port=0
+server.port=8080
 spring.datasource.url=jdbc:mysql://pricing-db:3306/pricingdb?createDatabaseIfNotExist=true&serverTimezone=UTC
 spring.datasource.username=${DB_USERNAME}
 spring.datasource.password=${DB_PASSWORD}

--- a/config-repo/reservation-service.properties
+++ b/config-repo/reservation-service.properties
@@ -1,4 +1,4 @@
-server.port=0
+server.port=8080
 spring.datasource.url=jdbc:mysql://reservation-db:3306/reservationdb?createDatabaseIfNotExist=true&serverTimezone=UTC
 spring.datasource.username=${DB_USERNAME}
 spring.datasource.password=${DB_PASSWORD}

--- a/k8s/client.yaml
+++ b/k8s/client.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata: {name: client-service}
+spec:
+  selector: {matchLabels: {app: client-service}}
+  template:
+    metadata: {labels: {app: client-service}}
+    spec:
+      containers:
+      - name: client
+        image: client-service:latest
+        envFrom: [{secretRef:{name: db-cred}}]
+        env:
+        - {name: SPRING_CONFIG_IMPORT, value: "configserver:http://config:8888"}
+        ports:
+        - {containerPort: 8080}
+        - {containerPort: 9090}
+        readinessProbe:
+          httpGet: {path: /actuator/health, port: 9090}
+          initialDelaySeconds: 10
+          periodSeconds: 10
+---
+apiVersion: v1
+kind: Service
+metadata: {name: client-service}
+spec:
+  ports: [{port: 8080}]
+  selector: {app: client-service}

--- a/k8s/config-repo-cm.yaml
+++ b/k8s/config-repo-cm.yaml
@@ -1,0 +1,4 @@
+# This ConfigMap should be generated with:
+# kubectl create configmap config-repo --from-file=config-repo/ \
+#        --dry-run=client -o yaml > k8s/config-repo-cm.yaml
+# The resulting YAML will include each *.properties file as a key.

--- a/k8s/frontend.yaml
+++ b/k8s/frontend.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata: {name: frontend}
+spec:
+  selector: {matchLabels: {app: frontend}}
+  template:
+    metadata: {labels: {app: frontend}}
+    spec:
+      containers:
+      - name: nginx
+        image: karting-frontend:latest
+        ports: [{containerPort: 80}]
+---
+apiVersion: v1
+kind: Service
+metadata: {name: frontend}
+spec:
+  type: NodePort
+  ports:
+  - port: 80
+    nodePort: 30080
+  selector: {app: frontend}

--- a/k8s/infra.yaml
+++ b/k8s/infra.yaml
@@ -1,0 +1,90 @@
+# ---------- Config-Server ----------
+apiVersion: apps/v1
+kind: Deployment
+metadata: {name: config}
+spec:
+  selector: {matchLabels: {app: config}}
+  template:
+    metadata: {labels: {app: config}}
+    spec:
+      volumes:
+      - name: config-repo
+        configMap: {name: config-repo}
+      containers:
+      - name: config
+        image: config-server:latest
+        ports:
+        - {containerPort: 8888}
+        - {containerPort: 9090}
+        env:
+        - {name: SPRING_PROFILES_ACTIVE, value: "native"}
+        volumeMounts:
+        - {name: config-repo, mountPath: /config-repo}
+        readinessProbe:
+          httpGet: {path: /actuator/health, port: 9090}
+          initialDelaySeconds: 10
+          periodSeconds: 10
+---
+kind: Service
+apiVersion: v1
+metadata: {name: config}
+spec:
+  ports: [{port: 8888}]
+  selector: {app: config}
+---
+# ---------- Eureka ----------
+apiVersion: apps/v1
+kind: Deployment
+metadata: {name: discovery}
+spec:
+  selector: {matchLabels: {app: discovery}}
+  template:
+    metadata: {labels: {app: discovery}}
+    spec:
+      containers:
+      - name: discovery
+        image: discovery-server:latest
+        ports:
+        - {containerPort: 8761}
+        - {containerPort: 9090}
+        readinessProbe:
+          httpGet: {path: /actuator/health, port: 9090}
+          initialDelaySeconds: 10
+          periodSeconds: 10
+---
+kind: Service
+apiVersion: v1
+metadata: {name: discovery}
+spec:
+  ports: [{port: 8761}]
+  selector: {app: discovery}
+---
+# ---------- API-Gateway ----------
+apiVersion: apps/v1
+kind: Deployment
+metadata: {name: gateway}
+spec:
+  selector: {matchLabels: {app: gateway}}
+  template:
+    metadata: {labels: {app: gateway}}
+    spec:
+      containers:
+      - name: gateway
+        image: gateway-service:latest
+        envFrom: [{secretRef:{name: db-cred}}]
+        env:
+        - {name: SPRING_CONFIG_IMPORT, value: "configserver:http://config:8888"}
+        ports:
+        - {containerPort: 8080}
+        - {containerPort: 9090}
+        readinessProbe:
+          httpGet: {path: /actuator/health, port: 9090}
+          initialDelaySeconds: 10
+          periodSeconds: 10
+---
+kind: Service
+apiVersion: v1
+metadata: {name: gateway}
+spec:
+  ports: [{port: 8080}]
+  selector: {app: gateway}

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -1,0 +1,20 @@
+resources:
+- infra.yaml
+- frontend.yaml
+- mysql-client.yaml
+- mysql-pricing.yaml
+- mysql-reservation.yaml
+- mysql-session.yaml
+- client.yaml
+- pricing.yaml
+- reservation.yaml
+- session.yaml
+- secrets.yaml
+- config-repo-cm.yaml
+configMapGenerator: []
+secretGenerator:
+- name: db-cred
+  literals:
+  - DB_USERNAME=karting
+  - DB_PASSWORD=kartingpwd
+  generatorOptions: {disableNameSuffixHash: true}

--- a/k8s/mysql-client.yaml
+++ b/k8s/mysql-client.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: Secret
+metadata: {name: mysql-client-secret}
+type: Opaque
+stringData:
+  MYSQL_ROOT_PASSWORD: root_pwd
+  MYSQL_PASSWORD: kartingpwd
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata: {name: mysql-client-pvc}
+spec:
+  accessModes: [ReadWriteOnce]
+  resources: {requests: {storage: 1Gi}}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata: {name: client-db}
+spec:
+  strategy: {type: Recreate}
+  selector: {matchLabels: {app: client-db}}
+  template:
+    metadata: {labels: {app: client-db}}
+    spec:
+      containers:
+      - name: mysql
+        image: mysql:8.0.33
+        envFrom: [{secretRef: {name: mysql-client-secret}}]
+        env:
+        - {name: MYSQL_DATABASE, value: clientsdb}
+        - {name: MYSQL_USER, value: karting}
+        ports: [{containerPort: 3306}]
+        volumeMounts: [{name: data, mountPath: /var/lib/mysql}]
+      volumes:
+      - name: data
+        persistentVolumeClaim: {claimName: mysql-client-pvc}
+---
+apiVersion: v1
+kind: Service
+metadata: {name: client-db}
+spec:
+  ports: [{port: 3306}]
+  selector: {app: client-db}

--- a/k8s/mysql-pricing.yaml
+++ b/k8s/mysql-pricing.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: Secret
+metadata: {name: mysql-pricing-secret}
+type: Opaque
+stringData:
+  MYSQL_ROOT_PASSWORD: root_pwd
+  MYSQL_PASSWORD: kartingpwd
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata: {name: mysql-pricing-pvc}
+spec:
+  accessModes: [ReadWriteOnce]
+  resources: {requests: {storage: 1Gi}}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata: {name: pricing-db}
+spec:
+  strategy: {type: Recreate}
+  selector: {matchLabels: {app: pricing-db}}
+  template:
+    metadata: {labels: {app: pricing-db}}
+    spec:
+      containers:
+      - name: mysql
+        image: mysql:8.0.33
+        envFrom: [{secretRef: {name: mysql-pricing-secret}}]
+        env:
+        - {name: MYSQL_DATABASE, value: pricingdb}
+        - {name: MYSQL_USER, value: karting}
+        ports: [{containerPort: 3306}]
+        volumeMounts: [{name: data, mountPath: /var/lib/mysql}]
+      volumes:
+      - name: data
+        persistentVolumeClaim: {claimName: mysql-pricing-pvc}
+---
+apiVersion: v1
+kind: Service
+metadata: {name: pricing-db}
+spec:
+  ports: [{port: 3306}]
+  selector: {app: pricing-db}

--- a/k8s/mysql-reservation.yaml
+++ b/k8s/mysql-reservation.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: Secret
+metadata: {name: mysql-reservation-secret}
+type: Opaque
+stringData:
+  MYSQL_ROOT_PASSWORD: root_pwd
+  MYSQL_PASSWORD: kartingpwd
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata: {name: mysql-reservation-pvc}
+spec:
+  accessModes: [ReadWriteOnce]
+  resources: {requests: {storage: 1Gi}}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata: {name: reservation-db}
+spec:
+  strategy: {type: Recreate}
+  selector: {matchLabels: {app: reservation-db}}
+  template:
+    metadata: {labels: {app: reservation-db}}
+    spec:
+      containers:
+      - name: mysql
+        image: mysql:8.0.33
+        envFrom: [{secretRef: {name: mysql-reservation-secret}}]
+        env:
+        - {name: MYSQL_DATABASE, value: reservationdb}
+        - {name: MYSQL_USER, value: karting}
+        ports: [{containerPort: 3306}]
+        volumeMounts: [{name: data, mountPath: /var/lib/mysql}]
+      volumes:
+      - name: data
+        persistentVolumeClaim: {claimName: mysql-reservation-pvc}
+---
+apiVersion: v1
+kind: Service
+metadata: {name: reservation-db}
+spec:
+  ports: [{port: 3306}]
+  selector: {app: reservation-db}

--- a/k8s/mysql-session.yaml
+++ b/k8s/mysql-session.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: Secret
+metadata: {name: mysql-session-secret}
+type: Opaque
+stringData:
+  MYSQL_ROOT_PASSWORD: root_pwd
+  MYSQL_PASSWORD: kartingpwd
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata: {name: mysql-session-pvc}
+spec:
+  accessModes: [ReadWriteOnce]
+  resources: {requests: {storage: 1Gi}}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata: {name: session-db}
+spec:
+  strategy: {type: Recreate}
+  selector: {matchLabels: {app: session-db}}
+  template:
+    metadata: {labels: {app: session-db}}
+    spec:
+      containers:
+      - name: mysql
+        image: mysql:8.0.33
+        envFrom: [{secretRef: {name: mysql-session-secret}}]
+        env:
+        - {name: MYSQL_DATABASE, value: sessiondb}
+        - {name: MYSQL_USER, value: karting}
+        ports: [{containerPort: 3306}]
+        volumeMounts: [{name: data, mountPath: /var/lib/mysql}]
+      volumes:
+      - name: data
+        persistentVolumeClaim: {claimName: mysql-session-pvc}
+---
+apiVersion: v1
+kind: Service
+metadata: {name: session-db}
+spec:
+  ports: [{port: 3306}]
+  selector: {app: session-db}

--- a/k8s/pricing.yaml
+++ b/k8s/pricing.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata: {name: pricing-service}
+spec:
+  selector: {matchLabels: {app: pricing-service}}
+  template:
+    metadata: {labels: {app: pricing-service}}
+    spec:
+      containers:
+      - name: pricing
+        image: pricing-service:latest
+        envFrom: [{secretRef:{name: db-cred}}]
+        env:
+        - {name: SPRING_CONFIG_IMPORT, value: "configserver:http://config:8888"}
+        - {name: SERVER_PORT,          value: "8080"}
+        ports:
+        - {containerPort: 8080}
+        - {containerPort: 9090}
+        readinessProbe:
+          httpGet: {path: /actuator/health, port: 9090}
+          initialDelaySeconds: 10
+          periodSeconds: 10
+---
+apiVersion: v1
+kind: Service
+metadata: {name: pricing-service}
+spec:
+  ports: [{port: 8080}]
+  selector: {app: pricing-service}

--- a/k8s/reservation.yaml
+++ b/k8s/reservation.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata: {name: reservation-service}
+spec:
+  selector: {matchLabels: {app: reservation-service}}
+  template:
+    metadata: {labels: {app: reservation-service}}
+    spec:
+      containers:
+      - name: reservation
+        image: reservation-service:latest
+        envFrom: [{secretRef:{name: db-cred}}]
+        env:
+        - {name: SPRING_CONFIG_IMPORT, value: "configserver:http://config:8888"}
+        - {name: SERVER_PORT,          value: "8080"}
+        ports:
+        - {containerPort: 8080}
+        - {containerPort: 9090}
+        readinessProbe:
+          httpGet: {path: /actuator/health, port: 9090}
+          initialDelaySeconds: 10
+          periodSeconds: 10
+---
+apiVersion: v1
+kind: Service
+metadata: {name: reservation-service}
+spec:
+  ports: [{port: 8080}]
+  selector: {app: reservation-service}

--- a/k8s/secrets.yaml
+++ b/k8s/secrets.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata: {name: db-cred}
+type: Opaque
+stringData:
+  DB_USERNAME: karting
+  DB_PASSWORD: kartingpwd

--- a/k8s/session.yaml
+++ b/k8s/session.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata: {name: session-service}
+spec:
+  selector: {matchLabels: {app: session-service}}
+  template:
+    metadata: {labels: {app: session-service}}
+    spec:
+      containers:
+      - name: session
+        image: session-service:latest
+        envFrom: [{secretRef:{name: db-cred}}]
+        env:
+        - {name: SPRING_CONFIG_IMPORT, value: "configserver:http://config:8888"}
+        ports:
+        - {containerPort: 8080}
+        - {containerPort: 9090}
+        readinessProbe:
+          httpGet: {path: /actuator/health, port: 9090}
+          initialDelaySeconds: 10
+          periodSeconds: 10
+---
+apiVersion: v1
+kind: Service
+metadata: {name: session-service}
+spec:
+  ports: [{port: 8080}]
+  selector: {app: session-service}


### PR DESCRIPTION
## Summary
- add Kubernetes manifests for all services and infrastructure under `k8s/`
- update `server.port` in pricing and reservation configs for k8s

## Testing
- `./mvnw -q -DskipTests package` *(fails: cannot resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684744469270832c8e5d199a1f121f58