### PR TITLE
Resolve critical audit items

### DIFF
--- a/config-repo/session-service.properties
+++ b/config-repo/session-service.properties
@@ -4,7 +4,7 @@ spring.datasource.password=${DB_PASSWORD}
 
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.open-in-view=false
-server.port=0
+server.port=8080
 
 spring.application.name=session-service
 eureka.client.service-url.defaultZone=http://discovery:8761/eureka/

--- a/k8s/config-repo-cm.yaml
+++ b/k8s/config-repo-cm.yaml
@@ -1,4 +1,95 @@
-# This ConfigMap should be generated with:
-# kubectl create configmap config-repo --from-file=config-repo/ \
-#        --dry-run=client -o yaml > k8s/config-repo-cm.yaml
-# The resulting YAML will include each *.properties file as a key.
+apiVersion: v1
+data:
+  client-service.properties: |
+    spring.datasource.url=jdbc:mysql://client-db:3306/clientsdb?serverTimezone=UTC&useSSL=false
+    spring.datasource.username=${DB_USERNAME}
+    spring.datasource.password=${DB_PASSWORD}
+    spring.jpa.defer-datasource-initialization=true
+    logging.level.org.springframework=INFO
+    management.endpoints.web.exposure.include=health,info,prometheus
+    management.metrics.tags.application=${spring.application.name}
+    management.server.port=9090
+    management.tracing.sampling.probability=1.0
+    management.zipkin.tracing.endpoint=http://zipkin:9411/api/v2/spans
+  discovery-service.properties: |
+    server.port=8761
+    spring.application.name=discovery-service
+    management.tracing.sampling.probability=1.0
+    management.zipkin.tracing.endpoint=http://zipkin:9411/api/v2/spans
+  gateway-service.properties: |
+    server.port=8080
+
+    spring.cloud.gateway.routes[0].id=client-route
+    spring.cloud.gateway.routes[0].uri=lb://CLIENT-SERVICE
+    spring.cloud.gateway.routes[0].predicates[0]=Path=/api/clients/**
+
+    spring.cloud.gateway.routes[1].id=pricing-route
+    spring.cloud.gateway.routes[1].uri=lb://PRICING-SERVICE
+    spring.cloud.gateway.routes[1].predicates[0]=Path=/api/pricing/**
+
+    spring.cloud.gateway.routes[2].id=reservation-route
+    spring.cloud.gateway.routes[2].uri=lb://RESERVATION-SERVICE
+    spring.cloud.gateway.routes[2].predicates[0]=Path=/api/reservations/**
+
+    spring.cloud.gateway.routes[3].id=session-route
+    spring.cloud.gateway.routes[3].uri=lb://SESSION-SERVICE
+    spring.cloud.gateway.routes[3].predicates[0]=Path=/api/sessions/**
+
+    eureka.client.service-url.defaultZone=http://discovery:8761/eureka/
+    management.endpoints.web.exposure.include=health,info,prometheus
+    management.metrics.tags.application=${spring.application.name}
+    management.endpoint.health.show-details=always
+    management.server.port=9090
+    management.tracing.sampling.probability=1.0
+    management.zipkin.tracing.endpoint=http://zipkin:9411/api/v2/spans
+  pricing-service.properties: |
+    server.port=8080
+    spring.datasource.url=jdbc:mysql://pricing-db:3306/pricingdb?createDatabaseIfNotExist=true&serverTimezone=UTC
+    spring.datasource.username=${DB_USERNAME}
+    spring.datasource.password=${DB_PASSWORD}
+    spring.sql.init.mode=always
+    spring.jpa.hibernate.ddl-auto=update
+    spring.jpa.defer-datasource-initialization=true
+    spring.jpa.open-in-view=false
+    logging.level.org.springframework=INFO
+    management.endpoints.web.exposure.include=health,info,prometheus
+    management.metrics.tags.application=${spring.application.name}
+    management.endpoint.health.show-details=always
+    management.server.port=9090
+    management.tracing.sampling.probability=1.0
+    management.zipkin.tracing.endpoint=http://zipkin:9411/api/v2/spans
+  reservation-service.properties: |
+    server.port=8080
+    spring.datasource.url=jdbc:mysql://reservation-db:3306/reservationdb?createDatabaseIfNotExist=true&serverTimezone=UTC
+    spring.datasource.username=${DB_USERNAME}
+    spring.datasource.password=${DB_PASSWORD}
+    spring.jpa.hibernate.ddl-auto=update
+    spring.jpa.open-in-view=false
+    logging.level.org.springframework=INFO
+    management.endpoints.web.exposure.include=health,info,prometheus
+    management.metrics.tags.application=${spring.application.name}
+    management.endpoint.health.show-details=always
+    management.server.port=9090
+    management.tracing.sampling.probability=1.0
+    management.zipkin.tracing.endpoint=http://zipkin:9411/api/v2/spans
+  session-service.properties: |
+    spring.datasource.url=jdbc:mysql://session-db:3306/sessiondb?createDatabaseIfNotExist=true&serverTimezone=UTC
+    spring.datasource.username=${DB_USERNAME}
+    spring.datasource.password=${DB_PASSWORD}
+
+    spring.jpa.hibernate.ddl-auto=update
+    spring.jpa.open-in-view=false
+    server.port=8080
+
+    spring.application.name=session-service
+    eureka.client.service-url.defaultZone=http://discovery:8761/eureka/
+
+    management.server.port=9090
+    management.endpoints.web.exposure.include=health,info,prometheus
+    management.metrics.tags.application=${spring.application.name}
+    management.tracing.sampling.probability=1.0
+    management.zipkin.tracing.endpoint=http://zipkin:9411/api/v2/spans
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  name: config-repo

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -3,10 +3,10 @@ scrape_configs:
     metrics_path: '/actuator/prometheus'
     static_configs:
       - targets:
-          - 'pricing:9090'
-          - 'reservation:9090'
-          - 'client:9090'
-          - 'session:9090'
+          - 'pricing-service:9090'
+          - 'reservation-service:9090'
+          - 'client-service:9090'
+          - 'session-service:9090'
           - 'gateway:9090'
           - 'config:9090'
           - 'discovery:9090'


### PR DESCRIPTION
## Summary
- set `server.port` for session-service
- correct k8s Prometheus targets for services
- generate ConfigMap with repo configs

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6847479efae8832cb38f526ccf11f616