### PR TITLE
Apply updates to Dockerfiles and pricing service

### DIFF
--- a/client-service/Dockerfile
+++ b/client-service/Dockerfile
@@ -27,5 +27,5 @@ WORKDIR /app
 ARG MODULE_NAME
 COPY --from=build /app/${MODULE_NAME}/target/${MODULE_NAME}-*.jar app.jar
 ENV JAVA_TOOL_OPTIONS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=60 -XX:+UseSerialGC"
-EXPOSE 9090
+EXPOSE 8080 9090
 ENTRYPOINT ["java","-jar","app.jar"]

--- a/config-repo/gateway-service.properties
+++ b/config-repo/gateway-service.properties
@@ -16,6 +16,10 @@ spring.cloud.gateway.routes[3].id=session-route
 spring.cloud.gateway.routes[3].uri=lb://SESSION-SERVICE
 spring.cloud.gateway.routes[3].predicates[0]=Path=/api/sessions/**
 
+spring.cloud.gateway.routes[4].id=tariffs-route
+spring.cloud.gateway.routes[4].uri=lb://PRICING-SERVICE
+spring.cloud.gateway.routes[4].predicates[0]=Path=/api/tariffs/**
+
 eureka.client.service-url.defaultZone=http://discovery:8761/eureka/
 management.endpoints.web.exposure.include=health,info,prometheus
 management.metrics.tags.application=${spring.application.name}

--- a/config-server/Dockerfile
+++ b/config-server/Dockerfile
@@ -27,5 +27,5 @@ WORKDIR /app
 ARG MODULE_NAME
 COPY --from=build /app/${MODULE_NAME}/target/${MODULE_NAME}-*.jar app.jar
 ENV JAVA_TOOL_OPTIONS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=60 -XX:+UseSerialGC"
-EXPOSE 9090
+EXPOSE 8080 9090
 ENTRYPOINT ["java","-jar","app.jar"]

--- a/discovery-server/Dockerfile
+++ b/discovery-server/Dockerfile
@@ -27,5 +27,5 @@ WORKDIR /app
 ARG MODULE_NAME
 COPY --from=build /app/${MODULE_NAME}/target/${MODULE_NAME}-*.jar app.jar
 ENV JAVA_TOOL_OPTIONS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=60 -XX:+UseSerialGC"
-EXPOSE 9090
+EXPOSE 8080 9090
 ENTRYPOINT ["java","-jar","app.jar"]

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -12,9 +12,3 @@ resources:
 - secrets.yaml
 - config-repo-cm.yaml
 configMapGenerator: []
-secretGenerator:
-- name: db-cred
-  literals:
-  - DB_USERNAME=karting
-  - DB_PASSWORD=kartingpwd
-  generatorOptions: {disableNameSuffixHash: true}

--- a/k8s/pricing.yaml
+++ b/k8s/pricing.yaml
@@ -12,7 +12,6 @@ spec:
         envFrom: [{secretRef:{name: db-cred}}]
         env:
         - {name: SPRING_CONFIG_IMPORT, value: "configserver:http://config:8888"}
-        - {name: SERVER_PORT,          value: "8080"}
         ports:
         - {containerPort: 8080}
         - {containerPort: 9090}

--- a/k8s/reservation.yaml
+++ b/k8s/reservation.yaml
@@ -12,7 +12,6 @@ spec:
         envFrom: [{secretRef:{name: db-cred}}]
         env:
         - {name: SPRING_CONFIG_IMPORT, value: "configserver:http://config:8888"}
-        - {name: SERVER_PORT,          value: "8080"}
         ports:
         - {containerPort: 8080}
         - {containerPort: 9090}

--- a/pricing-service/Dockerfile
+++ b/pricing-service/Dockerfile
@@ -27,5 +27,5 @@ WORKDIR /app
 ARG MODULE_NAME
 COPY --from=build /app/${MODULE_NAME}/target/${MODULE_NAME}-*.jar app.jar
 ENV JAVA_TOOL_OPTIONS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=60 -XX:+UseSerialGC"
-EXPOSE 9090
+EXPOSE 8080 9090
 ENTRYPOINT ["java","-jar","app.jar"]

--- a/pricing-service/src/main/java/cl/kartingrm/pricing_service/controller/TariffController.java
+++ b/pricing-service/src/main/java/cl/kartingrm/pricing_service/controller/TariffController.java
@@ -1,0 +1,33 @@
+package cl.kartingrm.pricing_service.controller;
+
+import cl.kartingrm.pricing_service.model.*;
+import cl.kartingrm.pricing_service.repository.TariffConfigRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+
+@RestController
+@RequestMapping("/api/tariffs")
+@RequiredArgsConstructor
+public class TariffController {
+
+    private final TariffConfigRepository repo;
+
+    @GetMapping
+    public List<TariffConfig> list() {
+        return repo.findAll();
+    }
+
+    @PutMapping("/{rate}")
+    public TariffConfig update(@PathVariable RateType rate,
+                               @RequestBody TariffConfig body) {
+
+        TariffConfig cfg = repo.findByRateTypeAndLaps(rate, body.getLaps())
+                .orElseThrow(() -> new NoSuchElementException("tarifa no encontrada"));
+        cfg.setBasePrice(body.getBasePrice());
+        cfg.setMinutes(body.getMinutes());
+        return repo.save(cfg);
+    }
+}

--- a/reservation-service/Dockerfile
+++ b/reservation-service/Dockerfile
@@ -27,5 +27,5 @@ WORKDIR /app
 ARG MODULE_NAME
 COPY --from=build /app/${MODULE_NAME}/target/${MODULE_NAME}-*.jar app.jar
 ENV JAVA_TOOL_OPTIONS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=60 -XX:+UseSerialGC"
-EXPOSE 9090
+EXPOSE 8080 9090
 ENTRYPOINT ["java","-jar","app.jar"]

--- a/session-service/Dockerfile
+++ b/session-service/Dockerfile
@@ -28,5 +28,5 @@ WORKDIR /app
 ARG MODULE_NAME
 COPY --from=build /app/${MODULE_NAME}/target/${MODULE_NAME}-*.jar app.jar
 ENV JAVA_TOOL_OPTIONS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=60 -XX:+UseSerialGC"
-EXPOSE 9090
+EXPOSE 8080 9090
 ENTRYPOINT ["java","-jar","app.jar"]


### PR DESCRIPTION
## Summary
- expose port 8080 in all service Dockerfiles
- clean SERVER_PORT env vars from Kubernetes manifests
- remove secret generator from Kustomize file
- add new `/api/tariffs` route for gateway
- implement `TariffController` in pricing service

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68474a3fd2e0832c938b5b2dc05623a6