### PR TITLE
Update tariffs route and frontend fields

### DIFF
--- a/discovery-server/Dockerfile
+++ b/discovery-server/Dockerfile
@@ -27,5 +27,5 @@ WORKDIR /app
 ARG MODULE_NAME
 COPY --from=build /app/${MODULE_NAME}/target/${MODULE_NAME}-*.jar app.jar
 ENV JAVA_TOOL_OPTIONS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=60 -XX:+UseSerialGC"
-EXPOSE 8080 9090
+EXPOSE 8080 8081 9090
 ENTRYPOINT ["java","-jar","app.jar"]

--- a/k8s/config-repo-cm.yaml
+++ b/k8s/config-repo-cm.yaml
@@ -35,6 +35,11 @@ data:
     spring.cloud.gateway.routes[3].uri=lb://SESSION-SERVICE
     spring.cloud.gateway.routes[3].predicates[0]=Path=/api/sessions/**
 
+    # --- NUEVO ---
+    spring.cloud.gateway.routes[4].id=tariffs-route
+    spring.cloud.gateway.routes[4].uri=lb://PRICING-SERVICE
+    spring.cloud.gateway.routes[4].predicates[0]=Path=/api/tariffs/**
+
     eureka.client.service-url.defaultZone=http://discovery:8761/eureka/
     management.endpoints.web.exposure.include=health,info,prometheus
     management.metrics.tags.application=${spring.application.name}

--- a/kartingrm-frontend/src/pages/TariffsCrud.jsx
+++ b/kartingrm-frontend/src/pages/TariffsCrud.jsx
@@ -10,7 +10,7 @@ export default function TariffsCrud(){
   useEffect(()=>{ tariffSvc.list().then(setRows) },[])
 
   const processRowUpdate = async (newRow) => {
-    await tariffSvc.update(newRow.rate, newRow)
+    await tariffSvc.update(newRow.rateType, newRow)
     return newRow
   }
 
@@ -19,11 +19,11 @@ export default function TariffsCrud(){
       <DataGrid
         rows={rows}
         columns={[
-          {field:'rate',     headerName:'Tarifa',   width:130, editable:false},
-          {field:'price',    headerName:'Precio',   width:130, editable:true, type:'number'},
+          {field:'rateType',     headerName:'Tarifa',   width:130, editable:false},
+          {field:'basePrice',    headerName:'Precio',   width:130, editable:true, type:'number'},
           {field:'minutes',  headerName:'Minutos',  width:130, editable:true, type:'number'}
         ]}
-        getRowId={r=>r.rate}
+        getRowId={r=>r.rateType}
         processRowUpdate={processRowUpdate}
         experimentalFeatures={{ newEditingApi: true }}
         autoHeight

--- a/kartingrm-frontend/src/services/tariff.service.js
+++ b/kartingrm-frontend/src/services/tariff.service.js
@@ -2,7 +2,7 @@
 import http from '../http-common'
 
 const list   = cfg => http.get('/tariffs', cfg).then(r => r.data)
-const update = (rate, payload, cfg={}) =>
-  http.put(`/tariffs/${rate}`, payload, cfg).then(r => r.data)
+const update = (rateType, payload, cfg={}) =>
+  http.put(`/tariffs/${rateType}`, payload, cfg).then(r => r.data)
 
 export default { list, update }


### PR DESCRIPTION
## Summary
- add /api/tariffs/** route to gateway config map
- adjust Tariffs CRUD screen to use new `rateType` and `basePrice` fields
- update tariff service for new parameter name
- document actuator port in discovery Dockerfile

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*
- `npm run lint` *(fails: 5 errors, 1 warning)*

------
https://chatgpt.com/codex/tasks/task_e_68474c83aeb4832cb958f55dfe246b66