### PR TITLE
Fix datasource URLs and gateway actuator

### DIFF
--- a/config-repo/client-service.properties
+++ b/config-repo/client-service.properties
@@ -1,4 +1,4 @@
-spring.datasource.url=jdbc:mysql://client-db:3306/clientsdb?serverTimezone=UTC&useSSL=false
+spring.datasource.url=jdbc:mysql://client-db:3306/clientsdb?serverTimezone=UTC&useSSL=false&allowPublicKeyRetrieval=true
 spring.datasource.username=${DB_USERNAME}
 spring.datasource.password=${DB_PASSWORD}
 spring.jpa.defer-datasource-initialization=true

--- a/config-repo/gateway-service.properties
+++ b/config-repo/gateway-service.properties
@@ -21,7 +21,7 @@ spring.cloud.gateway.routes[4].uri=lb://PRICING-SERVICE
 spring.cloud.gateway.routes[4].predicates[0]=Path=/api/tariffs/**
 
 eureka.client.service-url.defaultZone=http://discovery:8761/eureka/
-management.endpoints.web.exposure.include=health,info,prometheus
+management.endpoints.web.exposure.include=health,info,prometheus,gateway
 management.metrics.tags.application=${spring.application.name}
 management.endpoint.health.show-details=always
 management.server.port=9090

--- a/config-repo/pricing-service.properties
+++ b/config-repo/pricing-service.properties
@@ -1,5 +1,5 @@
 server.port=8080
-spring.datasource.url=jdbc:mysql://pricing-db:3306/pricingdb?createDatabaseIfNotExist=true&serverTimezone=UTC
+spring.datasource.url=jdbc:mysql://pricing-db:3306/pricingdb?createDatabaseIfNotExist=true&serverTimezone=UTC&allowPublicKeyRetrieval=true
 spring.datasource.username=${DB_USERNAME}
 spring.datasource.password=${DB_PASSWORD}
 spring.sql.init.mode=always

--- a/config-repo/reservation-service.properties
+++ b/config-repo/reservation-service.properties
@@ -1,5 +1,5 @@
 server.port=8080
-spring.datasource.url=jdbc:mysql://reservation-db:3306/reservationdb?createDatabaseIfNotExist=true&serverTimezone=UTC
+spring.datasource.url=jdbc:mysql://reservation-db:3306/reservationdb?createDatabaseIfNotExist=true&serverTimezone=UTC&allowPublicKeyRetrieval=true
 spring.datasource.username=${DB_USERNAME}
 spring.datasource.password=${DB_PASSWORD}
 spring.jpa.hibernate.ddl-auto=update

--- a/config-repo/session-service.properties
+++ b/config-repo/session-service.properties
@@ -1,4 +1,4 @@
-spring.datasource.url=jdbc:mysql://session-db:3306/sessiondb?createDatabaseIfNotExist=true&serverTimezone=UTC
+spring.datasource.url=jdbc:mysql://session-db:3306/sessiondb?createDatabaseIfNotExist=true&serverTimezone=UTC&allowPublicKeyRetrieval=true
 spring.datasource.username=${DB_USERNAME}
 spring.datasource.password=${DB_PASSWORD}
 

--- a/k8s/config-repo-cm.yaml
+++ b/k8s/config-repo-cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   client-service.properties: |
-    spring.datasource.url=jdbc:mysql://client-db:3306/clientsdb?serverTimezone=UTC&useSSL=false
+    spring.datasource.url=jdbc:mysql://client-db:3306/clientsdb?serverTimezone=UTC&useSSL=false&allowPublicKeyRetrieval=true
     spring.datasource.username=${DB_USERNAME}
     spring.datasource.password=${DB_PASSWORD}
     spring.jpa.defer-datasource-initialization=true
@@ -41,7 +41,7 @@ data:
     spring.cloud.gateway.routes[4].predicates[0]=Path=/api/tariffs/**
 
     eureka.client.service-url.defaultZone=http://discovery:8761/eureka/
-    management.endpoints.web.exposure.include=health,info,prometheus
+    management.endpoints.web.exposure.include=health,info,prometheus,gateway
     management.metrics.tags.application=${spring.application.name}
     management.endpoint.health.show-details=always
     management.server.port=9090
@@ -49,7 +49,7 @@ data:
     management.zipkin.tracing.endpoint=http://zipkin:9411/api/v2/spans
   pricing-service.properties: |
     server.port=8080
-    spring.datasource.url=jdbc:mysql://pricing-db:3306/pricingdb?createDatabaseIfNotExist=true&serverTimezone=UTC
+    spring.datasource.url=jdbc:mysql://pricing-db:3306/pricingdb?createDatabaseIfNotExist=true&serverTimezone=UTC&allowPublicKeyRetrieval=true
     spring.datasource.username=${DB_USERNAME}
     spring.datasource.password=${DB_PASSWORD}
     spring.sql.init.mode=always
@@ -65,7 +65,7 @@ data:
     management.zipkin.tracing.endpoint=http://zipkin:9411/api/v2/spans
   reservation-service.properties: |
     server.port=8080
-    spring.datasource.url=jdbc:mysql://reservation-db:3306/reservationdb?createDatabaseIfNotExist=true&serverTimezone=UTC
+    spring.datasource.url=jdbc:mysql://reservation-db:3306/reservationdb?createDatabaseIfNotExist=true&serverTimezone=UTC&allowPublicKeyRetrieval=true
     spring.datasource.username=${DB_USERNAME}
     spring.datasource.password=${DB_PASSWORD}
     spring.jpa.hibernate.ddl-auto=update
@@ -78,7 +78,7 @@ data:
     management.tracing.sampling.probability=1.0
     management.zipkin.tracing.endpoint=http://zipkin:9411/api/v2/spans
   session-service.properties: |
-    spring.datasource.url=jdbc:mysql://session-db:3306/sessiondb?createDatabaseIfNotExist=true&serverTimezone=UTC
+    spring.datasource.url=jdbc:mysql://session-db:3306/sessiondb?createDatabaseIfNotExist=true&serverTimezone=UTC&allowPublicKeyRetrieval=true
     spring.datasource.username=${DB_USERNAME}
     spring.datasource.password=${DB_PASSWORD}
 

--- a/kartingrm-frontend/nginx.conf
+++ b/kartingrm-frontend/nginx.conf
@@ -1,4 +1,6 @@
 server {
+    resolver 127.0.0.11 valid=10s;
+
     listen 80;
     root /usr/share/nginx/html;
     index index.html;
@@ -9,7 +11,7 @@ server {
 
     # Proxy API calls to the Spring Cloud Gateway
     location /api/ {
-        proxy_pass http://gateway:8080/api/;
+        proxy_pass http://gateway:8080;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
     }


### PR DESCRIPTION
## Summary
- allow JDBC public key retrieval for local MySQL
- expose gateway routes in Spring Actuator
- update nginx proxy to resolve gateway and avoid double `/api`
- update k8s config map accordingly

## Testing
- `./mvnw -q -pl pricing-service test` *(fails: Could not transfer artifact)*
- `./mvnw -q -pl reservation-service test` *(fails: Could not transfer artifact)*
- `npm test --silent` *(no output)*

------
https://chatgpt.com/codex/tasks/task_e_684762e56a08832c8207536d2ad910f2