### PR TITLE
Enable Flyway migrations

### DIFF
--- a/client-service/pom.xml
+++ b/client-service/pom.xml
@@ -38,6 +38,10 @@
             <artifactId>mysql-connector-j</artifactId>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
+        </dependency>
 
         <!-- Config Client -->
         <dependency>

--- a/client-service/src/main/resources/db/migration/V1__initial_schema.sql
+++ b/client-service/src/main/resources/db/migration/V1__initial_schema.sql
@@ -1,0 +1,16 @@
+CREATE TABLE clients (
+  id BIGINT AUTO_INCREMENT PRIMARY KEY,
+  email VARCHAR(120) NOT NULL UNIQUE,
+  name VARCHAR(120) NOT NULL,
+  phone VARCHAR(32),
+  registered_at DATETIME,
+  INDEX idx_clients_email (email)
+) ENGINE=InnoDB;
+
+CREATE TABLE visits (
+  id BIGINT AUTO_INCREMENT PRIMARY KEY,
+  client_id BIGINT NOT NULL,
+  visit_date DATE NOT NULL,
+  FOREIGN KEY (client_id) REFERENCES clients(id),
+  INDEX idx_visit_date (visit_date)
+) ENGINE=InnoDB;

--- a/client-service/src/test/resources/application-test.properties
+++ b/client-service/src/test/resources/application-test.properties
@@ -1,3 +1,3 @@
 spring.config.import=
 spring.datasource.url=jdbc:h2:mem:testdb
-spring.jpa.hibernate.ddl-auto=update
+spring.flyway.baseline-on-migrate=true

--- a/config-repo/client-service.properties
+++ b/config-repo/client-service.properties
@@ -3,6 +3,8 @@ spring.datasource.username=${DB_USERNAME}
 spring.datasource.password=${DB_PASSWORD}
 eureka.client.service-url.defaultZone=http://discovery:8761/eureka/
 
+spring.flyway.baseline-on-migrate=true
+
 
 #  solo la necesitas si ejecutas contra MySQL 8\u2002→ el Dialect lo autodetecta
 # spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect

--- a/config-repo/gateway-service.properties
+++ b/config-repo/gateway-service.properties
@@ -3,22 +3,27 @@ server.port=8080
 spring.cloud.gateway.routes[0].id=client-route
 spring.cloud.gateway.routes[0].uri=lb://CLIENT-SERVICE
 spring.cloud.gateway.routes[0].predicates[0]=Path=/api/clients/**
+spring.cloud.gateway.routes[0].filters[0]=StripPrefix=1
 
 spring.cloud.gateway.routes[1].id=pricing-route
 spring.cloud.gateway.routes[1].uri=lb://PRICING-SERVICE
 spring.cloud.gateway.routes[1].predicates[0]=Path=/api/pricing/**
+spring.cloud.gateway.routes[1].filters[0]=StripPrefix=1
 
 spring.cloud.gateway.routes[2].id=reservation-route
 spring.cloud.gateway.routes[2].uri=lb://RESERVATION-SERVICE
 spring.cloud.gateway.routes[2].predicates[0]=Path=/api/reservations/**
+spring.cloud.gateway.routes[2].filters[0]=StripPrefix=1
 
 spring.cloud.gateway.routes[3].id=session-route
 spring.cloud.gateway.routes[3].uri=lb://SESSION-SERVICE
 spring.cloud.gateway.routes[3].predicates[0]=Path=/api/sessions/**
+spring.cloud.gateway.routes[3].filters[0]=StripPrefix=1
 
 spring.cloud.gateway.routes[4].id=tariffs-route
 spring.cloud.gateway.routes[4].uri=lb://PRICING-SERVICE
 spring.cloud.gateway.routes[4].predicates[0]=Path=/api/tariffs/**
+spring.cloud.gateway.routes[4].filters[0]=StripPrefix=1
 
 eureka.client.service-url.defaultZone=http://discovery:8761/eureka/
 management.endpoints.web.exposure.include=health,info,prometheus,gateway

--- a/config-repo/pricing-service.properties
+++ b/config-repo/pricing-service.properties
@@ -2,8 +2,7 @@ server.port=8080
 spring.datasource.url=jdbc:mysql://pricing-db:3306/pricingdb?createDatabaseIfNotExist=true&serverTimezone=UTC&allowPublicKeyRetrieval=true
 spring.datasource.username=${DB_USERNAME}
 spring.datasource.password=${DB_PASSWORD}
-spring.sql.init.mode=always
-spring.jpa.hibernate.ddl-auto=update
+spring.flyway.baseline-on-migrate=true
 spring.jpa.defer-datasource-initialization=true
 spring.jpa.open-in-view=false
 logging.level.org.springframework=INFO

--- a/config-repo/reservation-service.properties
+++ b/config-repo/reservation-service.properties
@@ -2,7 +2,7 @@ server.port=8080
 spring.datasource.url=jdbc:mysql://reservation-db:3306/reservationdb?createDatabaseIfNotExist=true&serverTimezone=UTC&allowPublicKeyRetrieval=true
 spring.datasource.username=${DB_USERNAME}
 spring.datasource.password=${DB_PASSWORD}
-spring.jpa.hibernate.ddl-auto=update
+spring.flyway.baseline-on-migrate=true
 spring.jpa.open-in-view=false
 logging.level.org.springframework=INFO
 management.endpoints.web.exposure.include=health,info,prometheus

--- a/config-repo/session-service.properties
+++ b/config-repo/session-service.properties
@@ -2,7 +2,7 @@ spring.datasource.url=jdbc:mysql://session-db:3306/sessiondb?createDatabaseIfNot
 spring.datasource.username=${DB_USERNAME}
 spring.datasource.password=${DB_PASSWORD}
 
-spring.jpa.hibernate.ddl-auto=update
+spring.flyway.baseline-on-migrate=true
 spring.jpa.open-in-view=false
 server.port=8080
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,10 @@ services:
       MYSQL_USER: ${DB_USERNAME}
       MYSQL_PASSWORD: ${DB_PASSWORD}
       MYSQL_ROOT_PASSWORD: root_pwd
+      TZ: America/Santiago
+      LANG: en_US.utf8
+      CHARACTER_SET_SERVER: utf8mb4
+      COLLATION_SERVER: utf8mb4_unicode_ci
     volumes:
       - pricing-data:/var/lib/mysql
     healthcheck:
@@ -63,6 +67,10 @@ services:
       MYSQL_USER: ${DB_USERNAME}
       MYSQL_PASSWORD: ${DB_PASSWORD}
       MYSQL_ROOT_PASSWORD: root_pwd
+      TZ: America/Santiago
+      LANG: en_US.utf8
+      CHARACTER_SET_SERVER: utf8mb4
+      COLLATION_SERVER: utf8mb4_unicode_ci
     volumes:
       - reservation-data:/var/lib/mysql
     healthcheck:
@@ -81,6 +89,10 @@ services:
       MYSQL_USER: ${DB_USERNAME}
       MYSQL_PASSWORD: ${DB_PASSWORD}
       MYSQL_ROOT_PASSWORD: root_pwd
+      TZ: America/Santiago
+      LANG: en_US.utf8
+      CHARACTER_SET_SERVER: utf8mb4
+      COLLATION_SERVER: utf8mb4_unicode_ci
     volumes:
       - client-data:/var/lib/mysql
     healthcheck:
@@ -100,6 +112,10 @@ services:
       MYSQL_USER: ${DB_USERNAME}
       MYSQL_PASSWORD: ${DB_PASSWORD}
       MYSQL_ROOT_PASSWORD: root_pwd
+      TZ: America/Santiago
+      LANG: en_US.utf8
+      CHARACTER_SET_SERVER: utf8mb4
+      COLLATION_SERVER: utf8mb4_unicode_ci
     volumes:
       - session-data:/var/lib/mysql
     healthcheck:

--- a/k8s/config-repo-cm.yaml
+++ b/k8s/config-repo-cm.yaml
@@ -4,6 +4,7 @@ data:
     spring.datasource.url=jdbc:mysql://client-db:3306/clientsdb?createDatabaseIfNotExist=true&serverTimezone=UTC&allowPublicKeyRetrieval=true
     spring.datasource.username=${DB_USERNAME}
     spring.datasource.password=${DB_PASSWORD}
+    spring.flyway.baseline-on-migrate=true
     spring.jpa.defer-datasource-initialization=true
     logging.level.org.springframework=INFO
     management.endpoints.web.exposure.include=health,info,prometheus
@@ -22,23 +23,28 @@ data:
     spring.cloud.gateway.routes[0].id=client-route
     spring.cloud.gateway.routes[0].uri=lb://CLIENT-SERVICE
     spring.cloud.gateway.routes[0].predicates[0]=Path=/api/clients/**
+    spring.cloud.gateway.routes[0].filters[0]=StripPrefix=1
 
     spring.cloud.gateway.routes[1].id=pricing-route
     spring.cloud.gateway.routes[1].uri=lb://PRICING-SERVICE
     spring.cloud.gateway.routes[1].predicates[0]=Path=/api/pricing/**
+    spring.cloud.gateway.routes[1].filters[0]=StripPrefix=1
 
     spring.cloud.gateway.routes[2].id=reservation-route
     spring.cloud.gateway.routes[2].uri=lb://RESERVATION-SERVICE
     spring.cloud.gateway.routes[2].predicates[0]=Path=/api/reservations/**
+    spring.cloud.gateway.routes[2].filters[0]=StripPrefix=1
 
     spring.cloud.gateway.routes[3].id=session-route
     spring.cloud.gateway.routes[3].uri=lb://SESSION-SERVICE
     spring.cloud.gateway.routes[3].predicates[0]=Path=/api/sessions/**
+    spring.cloud.gateway.routes[3].filters[0]=StripPrefix=1
 
     # --- NUEVO ---
     spring.cloud.gateway.routes[4].id=tariffs-route
     spring.cloud.gateway.routes[4].uri=lb://PRICING-SERVICE
     spring.cloud.gateway.routes[4].predicates[0]=Path=/api/tariffs/**
+    spring.cloud.gateway.routes[4].filters[0]=StripPrefix=1
 
     eureka.client.service-url.defaultZone=http://discovery:8761/eureka/
     management.endpoints.web.exposure.include=health,info,prometheus,gateway
@@ -52,8 +58,7 @@ data:
     spring.datasource.url=jdbc:mysql://pricing-db:3306/pricingdb?createDatabaseIfNotExist=true&serverTimezone=UTC&allowPublicKeyRetrieval=true
     spring.datasource.username=${DB_USERNAME}
     spring.datasource.password=${DB_PASSWORD}
-    spring.sql.init.mode=always
-    spring.jpa.hibernate.ddl-auto=update
+    spring.flyway.baseline-on-migrate=true
     spring.jpa.defer-datasource-initialization=true
     spring.jpa.open-in-view=false
     logging.level.org.springframework=INFO
@@ -68,7 +73,7 @@ data:
     spring.datasource.url=jdbc:mysql://reservation-db:3306/reservationdb?createDatabaseIfNotExist=true&serverTimezone=UTC&allowPublicKeyRetrieval=true
     spring.datasource.username=${DB_USERNAME}
     spring.datasource.password=${DB_PASSWORD}
-    spring.jpa.hibernate.ddl-auto=update
+    spring.flyway.baseline-on-migrate=true
     spring.jpa.open-in-view=false
     logging.level.org.springframework=INFO
     management.endpoints.web.exposure.include=health,info,prometheus
@@ -82,7 +87,7 @@ data:
     spring.datasource.username=${DB_USERNAME}
     spring.datasource.password=${DB_PASSWORD}
 
-    spring.jpa.hibernate.ddl-auto=update
+    spring.flyway.baseline-on-migrate=true
     spring.jpa.open-in-view=false
     server.port=8080
 

--- a/k8s/mysql-client.yaml
+++ b/k8s/mysql-client.yaml
@@ -29,6 +29,10 @@ spec:
         env:
         - {name: MYSQL_DATABASE, value: clientsdb}
         - {name: MYSQL_USER, value: karting}
+        - {name: TZ, value: America/Santiago}
+        - {name: LANG, value: en_US.utf8}
+        - {name: CHARACTER_SET_SERVER, value: utf8mb4}
+        - {name: COLLATION_SERVER, value: utf8mb4_unicode_ci}
         ports: [{containerPort: 3306}]
         volumeMounts: [{name: data, mountPath: /var/lib/mysql}]
       volumes:

--- a/k8s/mysql-pricing.yaml
+++ b/k8s/mysql-pricing.yaml
@@ -29,6 +29,10 @@ spec:
         env:
         - {name: MYSQL_DATABASE, value: pricingdb}
         - {name: MYSQL_USER, value: karting}
+        - {name: TZ, value: America/Santiago}
+        - {name: LANG, value: en_US.utf8}
+        - {name: CHARACTER_SET_SERVER, value: utf8mb4}
+        - {name: COLLATION_SERVER, value: utf8mb4_unicode_ci}
         ports: [{containerPort: 3306}]
         volumeMounts: [{name: data, mountPath: /var/lib/mysql}]
       volumes:

--- a/k8s/mysql-reservation.yaml
+++ b/k8s/mysql-reservation.yaml
@@ -29,6 +29,10 @@ spec:
         env:
         - {name: MYSQL_DATABASE, value: reservationdb}
         - {name: MYSQL_USER, value: karting}
+        - {name: TZ, value: America/Santiago}
+        - {name: LANG, value: en_US.utf8}
+        - {name: CHARACTER_SET_SERVER, value: utf8mb4}
+        - {name: COLLATION_SERVER, value: utf8mb4_unicode_ci}
         ports: [{containerPort: 3306}]
         volumeMounts: [{name: data, mountPath: /var/lib/mysql}]
       volumes:

--- a/k8s/mysql-session.yaml
+++ b/k8s/mysql-session.yaml
@@ -29,6 +29,10 @@ spec:
         env:
         - {name: MYSQL_DATABASE, value: sessiondb}
         - {name: MYSQL_USER, value: karting}
+        - {name: TZ, value: America/Santiago}
+        - {name: LANG, value: en_US.utf8}
+        - {name: CHARACTER_SET_SERVER, value: utf8mb4}
+        - {name: COLLATION_SERVER, value: utf8mb4_unicode_ci}
         ports: [{containerPort: 3306}]
         volumeMounts: [{name: data, mountPath: /var/lib/mysql}]
       volumes:

--- a/pricing-service/pom.xml
+++ b/pricing-service/pom.xml
@@ -34,11 +34,15 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>com.mysql</groupId>
-			<artifactId>mysql-connector-j</artifactId>
-			<scope>runtime</scope>
-		</dependency>
+               <dependency>
+                       <groupId>com.mysql</groupId>
+                       <artifactId>mysql-connector-j</artifactId>
+                       <scope>runtime</scope>
+               </dependency>
+               <dependency>
+                       <groupId>org.flywaydb</groupId>
+                       <artifactId>flyway-core</artifactId>
+               </dependency>
 
                 <!-- Validación de DTOs -->
                 <dependency>

--- a/pricing-service/src/main/resources/db/migration/V1__tariff_schema.sql
+++ b/pricing-service/src/main/resources/db/migration/V1__tariff_schema.sql
@@ -1,4 +1,4 @@
-CREATE TABLE IF NOT EXISTS tariff_config(
+CREATE TABLE tariff_config(
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
     rate_type VARCHAR(10) NOT NULL,
     laps INT NOT NULL,

--- a/pricing-service/src/main/resources/db/migration/V2__seed_tariffs.sql
+++ b/pricing-service/src/main/resources/db/migration/V2__seed_tariffs.sql
@@ -1,4 +1,3 @@
--- Inserción idempotente: se actualiza base_price si ya existe
 INSERT INTO tariff_config(rate_type,laps,minutes,base_price)
 VALUES
   ('WEEKDAY',10,10,15000),

--- a/pricing-service/src/test/resources/application-test.properties
+++ b/pricing-service/src/test/resources/application-test.properties
@@ -1,3 +1,3 @@
 spring.config.import=
 spring.datasource.url=jdbc:h2:mem:testdb
-spring.jpa.hibernate.ddl-auto=update
+spring.flyway.baseline-on-migrate=true

--- a/reservation-service/pom.xml
+++ b/reservation-service/pom.xml
@@ -34,11 +34,15 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>com.mysql</groupId>
-			<artifactId>mysql-connector-j</artifactId>
-			<scope>runtime</scope>
-		</dependency>
+               <dependency>
+                       <groupId>com.mysql</groupId>
+                       <artifactId>mysql-connector-j</artifactId>
+                       <scope>runtime</scope>
+               </dependency>
+               <dependency>
+                       <groupId>org.flywaydb</groupId>
+                       <artifactId>flyway-core</artifactId>
+               </dependency>
 
                 <!-- Validación de DTOs -->
                 <dependency>

--- a/reservation-service/src/main/resources/db/migration/V1__initial_schema.sql
+++ b/reservation-service/src/main/resources/db/migration/V1__initial_schema.sql
@@ -1,0 +1,11 @@
+CREATE TABLE reservation (
+  id BIGINT AUTO_INCREMENT PRIMARY KEY,
+  laps INT NOT NULL,
+  participants INT NOT NULL,
+  session_id BIGINT,
+  client_email VARCHAR(255),
+  base_price INT NOT NULL,
+  discount_percent INT NOT NULL,
+  final_price INT NOT NULL,
+  status VARCHAR(32)
+) ENGINE=InnoDB;

--- a/reservation-service/src/main/resources/db/migration/V2__add_indexes.sql
+++ b/reservation-service/src/main/resources/db/migration/V2__add_indexes.sql
@@ -1,0 +1,1 @@
+CREATE INDEX idx_reservation_session ON reservation(session_id);

--- a/reservation-service/src/test/resources/application-test.properties
+++ b/reservation-service/src/test/resources/application-test.properties
@@ -1,3 +1,3 @@
 spring.config.import=
 spring.datasource.url=jdbc:h2:mem:testdb
-spring.jpa.hibernate.ddl-auto=update
+spring.flyway.baseline-on-migrate=true

--- a/session-service/pom.xml
+++ b/session-service/pom.xml
@@ -31,11 +31,15 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
-        <dependency>
-            <groupId>com.mysql</groupId>
-            <artifactId>mysql-connector-j</artifactId>
-            <scope>runtime</scope>
-        </dependency>
+       <dependency>
+           <groupId>com.mysql</groupId>
+           <artifactId>mysql-connector-j</artifactId>
+           <scope>runtime</scope>
+       </dependency>
+       <dependency>
+           <groupId>org.flywaydb</groupId>
+           <artifactId>flyway-core</artifactId>
+       </dependency>
 
         <!-- Config Client -->
         <dependency>

--- a/session-service/src/main/resources/db/migration/V1__initial_schema.sql
+++ b/session-service/src/main/resources/db/migration/V1__initial_schema.sql
@@ -1,0 +1,10 @@
+CREATE TABLE sessions (
+  id BIGINT AUTO_INCREMENT PRIMARY KEY,
+  session_date DATE NOT NULL,
+  start_time TIME NOT NULL,
+  end_time TIME NOT NULL,
+  capacity INT,
+  version BIGINT,
+  participants_count INT DEFAULT 0,
+  UNIQUE KEY uq_session_unique(session_date,start_time,end_time)
+) ENGINE=InnoDB;

--- a/session-service/src/main/resources/db/migration/V2__add_indexes.sql
+++ b/session-service/src/main/resources/db/migration/V2__add_indexes.sql
@@ -1,0 +1,1 @@
+CREATE INDEX idx_session_date_start ON sessions(session_date,start_time);

--- a/session-service/src/test/resources/application-test.properties
+++ b/session-service/src/test/resources/application-test.properties
@@ -1,3 +1,3 @@
 spring.config.import=
 spring.datasource.url=jdbc:h2:mem:testdb
-spring.jpa.hibernate.ddl-auto=update
+spring.flyway.baseline-on-migrate=true


### PR DESCRIPTION
## Summary
- add Flyway to all JPA services
- migrate SQL scripts into Flyway migrations
- use MySQL utf8mb4 defaults in compose and k8s
- strip `/api` prefix in gateway
- drop JPA schema generation from configuration

## Testing
- `mvn test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6847892a47e8832c943d5ce17027af5d