### PR TITLE
Add stub services

### DIFF
--- a/k8s/config-repo-cm.yaml
+++ b/k8s/config-repo-cm.yaml
@@ -13,6 +13,7 @@ data:
     management.server.port=9090
     management.tracing.sampling.probability=1.0
     management.zipkin.tracing.endpoint=http://zipkin:9411/api/v2/spans
+    eureka.client.service-url.defaultZone=http://discovery:8761/eureka/
   discovery-service.properties: |
     server.port=8761
     spring.application.name=discovery-service
@@ -47,6 +48,16 @@ data:
     spring.cloud.gateway.routes[4].predicates[0]=Path=/api/tariffs/**
     spring.cloud.gateway.routes[4].filters[0]=StripPrefix=1
 
+    spring.cloud.gateway.routes[5].id=payment
+    spring.cloud.gateway.routes[5].uri=lb://PAYMENT-SERVICE
+    spring.cloud.gateway.routes[5].predicates[0]=Path=/api/payments/**
+    spring.cloud.gateway.routes[5].filters[0]=StripPrefix=1
+
+    spring.cloud.gateway.routes[6].id=report
+    spring.cloud.gateway.routes[6].uri=lb://REPORT-SERVICE
+    spring.cloud.gateway.routes[6].predicates[0]=Path=/api/reports/**
+    spring.cloud.gateway.routes[6].filters[0]=StripPrefix=1
+
     eureka.client.service-url.defaultZone=http://discovery:8761/eureka/
     management.endpoints.web.exposure.include=health,info,prometheus,gateway
     management.metrics.tags.application=${spring.application.name}
@@ -69,6 +80,7 @@ data:
     management.server.port=9090
     management.tracing.sampling.probability=1.0
     management.zipkin.tracing.endpoint=http://zipkin:9411/api/v2/spans
+    eureka.client.service-url.defaultZone=http://discovery:8761/eureka/
   reservation-service.properties: |
     server.port=8080
     spring.datasource.url=jdbc:mysql://reservation-db:3306/reservationdb?createDatabaseIfNotExist=true&serverTimezone=UTC&allowPublicKeyRetrieval=true
@@ -84,6 +96,7 @@ data:
     management.server.port=9090
     management.tracing.sampling.probability=1.0
     management.zipkin.tracing.endpoint=http://zipkin:9411/api/v2/spans
+    eureka.client.service-url.defaultZone=http://discovery:8761/eureka/
   session-service.properties: |
     spring.datasource.url=jdbc:mysql://session-db:3306/sessiondb?createDatabaseIfNotExist=true&serverTimezone=UTC&allowPublicKeyRetrieval=true
     spring.datasource.username=${DB_USERNAME}

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -9,6 +9,8 @@ resources:
 - pricing.yaml
 - reservation.yaml
 - session.yaml
+- payment.yaml
+- report.yaml
 - secrets.yaml
 - config-repo-cm.yaml
 configMapGenerator: []

--- a/k8s/payment.yaml
+++ b/k8s/payment.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata: {name: payment-service}
+spec:
+  selector: {matchLabels: {app: payment-service}}
+  template:
+    metadata: {labels: {app: payment-service}}
+    spec:
+      containers:
+      - name: payment
+        image: payment-service:latest
+        imagePullPolicy: Never
+        env:
+        - {name: SPRING_CONFIG_IMPORT, value: "configserver:http://config:8888"}
+        ports:
+        - {containerPort: 8080}
+        - {containerPort: 9090}
+        readinessProbe:
+          httpGet: {path: /actuator/health, port: 9090}
+          initialDelaySeconds: 10
+          periodSeconds: 10
+---
+apiVersion: v1
+kind: Service
+metadata: {name: payment-service}
+spec:
+  ports: [{port: 8080}]
+  selector: {app: payment-service}

--- a/k8s/report.yaml
+++ b/k8s/report.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata: {name: report-service}
+spec:
+  selector: {matchLabels: {app: report-service}}
+  template:
+    metadata: {labels: {app: report-service}}
+    spec:
+      containers:
+      - name: report
+        image: report-service:latest
+        imagePullPolicy: Never
+        env:
+        - {name: SPRING_CONFIG_IMPORT, value: "configserver:http://config:8888"}
+        ports:
+        - {containerPort: 8080}
+        - {containerPort: 9090}
+        readinessProbe:
+          httpGet: {path: /actuator/health, port: 9090}
+          initialDelaySeconds: 10
+          periodSeconds: 10
+---
+apiVersion: v1
+kind: Service
+metadata: {name: report-service}
+spec:
+  ports: [{port: 8080}]
+  selector: {app: report-service}

--- a/payment-service/src/main/java/cl/kartingrm/payment_service/controller/PaymentController.java
+++ b/payment-service/src/main/java/cl/kartingrm/payment_service/controller/PaymentController.java
@@ -1,15 +1,24 @@
 package cl.kartingrm.payment_service.controller;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/payments")
 public class PaymentController {
     @PostMapping
-    public ResponseEntity<Void> pay() {
-        return ResponseEntity.ok().build();
+    public Map<String, Long> pay() {
+        return Map.of("id", 123L);
+    }
+
+    @GetMapping("/{id}/receipt")
+    public ResponseEntity<byte[]> pdf(@PathVariable Long id) {
+        return ResponseEntity.ok().body(new byte[0]);
     }
 }


### PR DESCRIPTION
## Summary
- register `client`, `pricing` and `reservation` services with Eureka
- expose payment and report routes through the gateway
- create payment and report deployment manifests
- add missing stub logic in `PaymentController`
- include new manifests in kustomization

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6847a3e2b7f0832c80d556d1a5484e13