### PR TITLE
Add configs and mock report endpoints

### DIFF
--- a/config-repo/payment-service.properties
+++ b/config-repo/payment-service.properties
@@ -1,0 +1,4 @@
+server.port=8080
+spring.application.name=payment-service
+eureka.client.service-url.defaultZone=http://discovery:8761/eureka/
+management.server.port=9090

--- a/config-repo/report-service.properties
+++ b/config-repo/report-service.properties
@@ -1,0 +1,4 @@
+server.port=8080
+spring.application.name=report-service
+eureka.client.service-url.defaultZone=http://discovery:8761/eureka/
+management.server.port=9090

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -236,6 +236,58 @@ services:
       timeout: 5s
       retries: 30
 
+  payment:
+    build:
+      context: .
+      dockerfile: payment-service/Dockerfile
+      args:
+        MODULE_NAME: payment-service
+    container_name: payment
+    env_file: .env
+    environment:
+      - SPRING_CONFIG_IMPORT=configserver:http://config:8888
+      - SPRING_CLOUD_CONFIG_RETRY_INITIAL_INTERVAL=1000
+      - SPRING_CLOUD_CONFIG_RETRY_MULTIPLIER=1.5
+      - SPRING_CLOUD_CONFIG_RETRY_MAX_INTERVAL=20000
+      - SPRING_CLOUD_CONFIG_RETRY_MAX_ATTEMPTS=6
+    depends_on:
+      config:
+        condition: service_healthy
+      discovery:
+        condition: service_healthy
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9090/actuator/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+
+  report:
+    build:
+      context: .
+      dockerfile: report-service/Dockerfile
+      args:
+        MODULE_NAME: report-service
+    container_name: report
+    env_file: .env
+    environment:
+      - SPRING_CONFIG_IMPORT=configserver:http://config:8888
+      - SPRING_CLOUD_CONFIG_RETRY_INITIAL_INTERVAL=1000
+      - SPRING_CLOUD_CONFIG_RETRY_MULTIPLIER=1.5
+      - SPRING_CLOUD_CONFIG_RETRY_MAX_INTERVAL=20000
+      - SPRING_CLOUD_CONFIG_RETRY_MAX_ATTEMPTS=6
+    depends_on:
+      config:
+        condition: service_healthy
+      discovery:
+        condition: service_healthy
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9090/actuator/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+
   gateway:
     build:
       context: .

--- a/report-service/src/main/java/cl/kartingrm/report_service/controller/ReportController.java
+++ b/report-service/src/main/java/cl/kartingrm/report_service/controller/ReportController.java
@@ -1,9 +1,14 @@
 package cl.kartingrm.report_service.controller;
 
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/reports")
@@ -11,5 +16,26 @@ public class ReportController {
     @GetMapping
     public ResponseEntity<Void> ok() {
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/by-rate")
+    public List<Map<String, Object>> byRate(@RequestParam String from,
+                                            @RequestParam String to) {
+        return List.of();
+    }
+
+    @GetMapping("/by-group")
+    public List<Map<String, Object>> byGroup(@RequestParam String from,
+                                             @RequestParam String to) {
+        return List.of();
+    }
+
+    @GetMapping("/by-rate/csv")
+    public ResponseEntity<byte[]> csv(@RequestParam String from,
+                                      @RequestParam String to) {
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION,
+                        "attachment; filename=report.csv")
+                .body("rate,total\n".getBytes());
     }
 }


### PR DESCRIPTION
## Summary
- add payment and report configs to config repo
- mock report endpoints for basic data
- add payment and report services to compose for docker usage

## Testing
- `./mvnw -q -pl report-service -am test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6847a83f5f28832cad6051cff108b624