### PR TITLE
Add flyway-mysql dependency

### DIFF
--- a/client-service/pom.xml
+++ b/client-service/pom.xml
@@ -38,10 +38,14 @@
             <artifactId>mysql-connector-j</artifactId>
             <scope>runtime</scope>
         </dependency>
-        <dependency>
-            <groupId>org.flywaydb</groupId>
-            <artifactId>flyway-core</artifactId>
-        </dependency>
+       <dependency>
+           <groupId>org.flywaydb</groupId>
+           <artifactId>flyway-core</artifactId>
+       </dependency>
+       <dependency>
+           <groupId>org.flywaydb</groupId>
+           <artifactId>flyway-mysql</artifactId>
+       </dependency>
 
         <!-- Config Client -->
         <dependency>

--- a/pricing-service/pom.xml
+++ b/pricing-service/pom.xml
@@ -43,6 +43,10 @@
                        <groupId>org.flywaydb</groupId>
                        <artifactId>flyway-core</artifactId>
                </dependency>
+               <dependency>
+                       <groupId>org.flywaydb</groupId>
+                       <artifactId>flyway-mysql</artifactId>
+               </dependency>
 
                 <!-- Validación de DTOs -->
                 <dependency>

--- a/reservation-service/pom.xml
+++ b/reservation-service/pom.xml
@@ -39,10 +39,14 @@
                        <artifactId>mysql-connector-j</artifactId>
                        <scope>runtime</scope>
                </dependency>
-               <dependency>
-                       <groupId>org.flywaydb</groupId>
-                       <artifactId>flyway-core</artifactId>
-               </dependency>
+              <dependency>
+                      <groupId>org.flywaydb</groupId>
+                      <artifactId>flyway-core</artifactId>
+              </dependency>
+              <dependency>
+                      <groupId>org.flywaydb</groupId>
+                      <artifactId>flyway-mysql</artifactId>
+              </dependency>
 
                 <!-- Validación de DTOs -->
                 <dependency>

--- a/session-service/pom.xml
+++ b/session-service/pom.xml
@@ -36,10 +36,14 @@
            <artifactId>mysql-connector-j</artifactId>
            <scope>runtime</scope>
        </dependency>
-       <dependency>
-           <groupId>org.flywaydb</groupId>
-           <artifactId>flyway-core</artifactId>
-       </dependency>
+      <dependency>
+          <groupId>org.flywaydb</groupId>
+          <artifactId>flyway-core</artifactId>
+      </dependency>
+      <dependency>
+          <groupId>org.flywaydb</groupId>
+          <artifactId>flyway-mysql</artifactId>
+      </dependency>
 
         <!-- Config Client -->
         <dependency>


### PR DESCRIPTION
## Summary
- add `flyway-mysql` dependency to pricing-service, reservation-service, client-service and session-service

## Testing
- `./mvnw -q test -pl pricing-service,reservation-service,client-service,session-service -am` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6847ad2f5304832c8882e4fc92b37f90