### PR TITLE
Update axios base URL and endpoints

### DIFF
--- a/kartingrm-frontend/src/http-common.js
+++ b/kartingrm-frontend/src/http-common.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-const base = import.meta.env.VITE_API_BASE_URL || '/api';
+const base = '';
 
 const http = axios.create({
   baseURL: base,

--- a/kartingrm-frontend/src/services/client.service.js
+++ b/kartingrm-frontend/src/services/client.service.js
@@ -3,10 +3,10 @@ import http from '../http-common'
 /**
  *  Todos los métodos aceptan un objeto opcional (signal, headers, …)
  */
-const getAll = (cfg = {})         => http.get('/clients',        cfg)
-const get    = (id, cfg = {})     => http.get(`/clients/${id}`,   cfg)
-const create = (payload, cfg = {})=> http.post('/clients', payload, cfg).then(r => r.data)
+const getAll = (cfg = {})         => http.get('/api/clients',        cfg)
+const get    = (id, cfg = {})     => http.get(`/api/clients/${id}`,   cfg)
+const create = (payload, cfg = {})=> http.post('/api/clients', payload, cfg).then(r => r.data)
 const update = (id, payload, cfg={}) =>
-  http.put(`/clients/${id}`, payload, cfg).then(r => r.data)
+  http.put(`/api/clients/${id}`, payload, cfg).then(r => r.data)
 
 export default { getAll, get, create, update }

--- a/kartingrm-frontend/src/services/payment.service.js
+++ b/kartingrm-frontend/src/services/payment.service.js
@@ -1,4 +1,4 @@
 import http from '../http-common'
-const pay   = payload => http.post('/payments', payload)
-const receipt = id    => http.get(`/payments/${id}/receipt`, { responseType:'blob'})
+const pay   = payload => http.post('/api/payments', payload)
+const receipt = id    => http.get(`/api/payments/${id}/receipt`, { responseType:'blob'})
 export default { pay, receipt }

--- a/kartingrm-frontend/src/services/report.service.js
+++ b/kartingrm-frontend/src/services/report.service.js
@@ -1,4 +1,4 @@
 import http from '../http-common'
-const byRate  = (from,to) => http.get('/reports/by-rate',  {params:{from,to}})
-const byGroup = (from,to) => http.get('/reports/by-group', {params:{from,to}})
+const byRate  = (from,to) => http.get('/api/reports/by-rate',  {params:{from,to}})
+const byGroup = (from,to) => http.get('/api/reports/by-group', {params:{from,to}})
 export default { byRate, byGroup }

--- a/kartingrm-frontend/src/services/reservation.service.js
+++ b/kartingrm-frontend/src/services/reservation.service.js
@@ -1,7 +1,7 @@
 import http from '../http-common'
 
-const list   = ()        => http.get('/reservations')
-const create = payload   => http.post('/reservations', payload).then(r => r.data)
-const cancel = id        => http.patch(`/reservations/${id}/cancel`)
+const list   = ()        => http.get('/api/reservations')
+const create = payload   => http.post('/api/reservations', payload).then(r => r.data)
+const cancel = id        => http.patch(`/api/reservations/${id}/cancel`)
 
 export default { list, create, cancel }

--- a/kartingrm-frontend/src/services/session.service.js
+++ b/kartingrm-frontend/src/services/session.service.js
@@ -1,11 +1,11 @@
 import http from '../http-common'
 
 const weekly = (from, to, cfg = {}) =>
-  http.get('/sessions/availability', { params:{ from, to }, ...cfg })
+  http.get('/api/sessions/availability', { params:{ from, to }, ...cfg })
 
-const getAll = (cfg = {})            => http.get('/sessions', cfg)
-const create = (payload, cfg = {})   => http.post('/sessions', payload, cfg).then(r => r.data)
-const update = (id, payload, cfg={}) => http.put(`/sessions/${id}`, payload, cfg).then(r => r.data)
-const remove = (id, cfg = {})        => http.delete(`/sessions/${id}`, cfg)
+const getAll = (cfg = {})            => http.get('/api/sessions', cfg)
+const create = (payload, cfg = {})   => http.post('/api/sessions', payload, cfg).then(r => r.data)
+const update = (id, payload, cfg={}) => http.put(`/api/sessions/${id}`, payload, cfg).then(r => r.data)
+const remove = (id, cfg = {})        => http.delete(`/api/sessions/${id}`, cfg)
 
 export default { weekly, getAll, create, update, delete: remove }

--- a/kartingrm-frontend/src/services/tariff.service.js
+++ b/kartingrm-frontend/src/services/tariff.service.js
@@ -1,8 +1,8 @@
 // src/services/tariff.service.js
 import http from '../http-common'
 
-const list   = cfg => http.get('/tariffs', cfg).then(r => r.data)
+const list   = cfg => http.get('/api/tariffs', cfg).then(r => r.data)
 const update = (rateType, payload, cfg={}) =>
-  http.put(`/tariffs/${rateType}`, payload, cfg).then(r => r.data)
+  http.put(`/api/tariffs/${rateType}`, payload, cfg).then(r => r.data)
 
 export default { list, update }


### PR DESCRIPTION
## Summary
- set axios `baseURL` to an empty string
- prefix service calls with `/api`

## Testing
- `npm run lint` *(fails: 5 errors, 1 warning)*

------
https://chatgpt.com/codex/tasks/task_e_6847b5864fd4832cba780044198736f2