### PR TITLE
Fix nginx config not copied to Docker image

### DIFF
--- a/kartingrm-frontend/Dockerfile
+++ b/kartingrm-frontend/Dockerfile
@@ -9,5 +9,7 @@ RUN npm run build
 # Stage 2: Servir con Nginx
 FROM nginx:stable
 COPY --from=build /app/dist /usr/share/nginx/html
+# ❶ Sustituye el vhost por defecto con el nuestro
+COPY nginx.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80
 ENTRYPOINT ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## Summary
- copy custom nginx.conf into docker image for `kartingrm-frontend`

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6847bdcb9970832c90edfc297a12b2f1