### PR TITLE
Implement DTO validation and frontend fixes

### DIFF
--- a/client-service/pom.xml
+++ b/client-service/pom.xml
@@ -47,6 +47,12 @@
            <artifactId>flyway-mysql</artifactId>
        </dependency>
 
+        <!-- Validación de DTOs -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+
         <!-- Config Client -->
         <dependency>
             <groupId>org.springframework.cloud</groupId>

--- a/client-service/src/main/java/cl/kartingrm/client_service/controller/ApiExceptionHandler.java
+++ b/client-service/src/main/java/cl/kartingrm/client_service/controller/ApiExceptionHandler.java
@@ -1,0 +1,22 @@
+package cl.kartingrm.client_service.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Map;
+
+@RestControllerAdvice
+public class ApiExceptionHandler {
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<?> badInput(MethodArgumentNotValidException ex){
+        var errs = ex.getBindingResult().getFieldErrors()
+                .stream()
+                .map(f -> Map.of(
+                        "field", f.getField(),
+                        "msg",   f.getDefaultMessage()))
+                .toList();
+        return ResponseEntity.badRequest().body(errs);
+    }
+}

--- a/client-service/src/main/java/cl/kartingrm/client_service/controller/ClientController.java
+++ b/client-service/src/main/java/cl/kartingrm/client_service/controller/ClientController.java
@@ -1,7 +1,10 @@
 package cl.kartingrm.client_service.controller;
 
+import cl.kartingrm.client_service.dto.ClientDTO;
 import cl.kartingrm.client_service.model.Client;
 import cl.kartingrm.client_service.service.ClientService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -18,11 +21,18 @@ public class ClientController {
     }
 
     @PostMapping
-    public ResponseEntity<Client> createClient(@RequestBody Client clientData) {
-        if (clientService.findByEmail(clientData.getEmail()).isPresent()) {
-            return ResponseEntity.badRequest().build();
-        }
-        Client saved = clientService.registerClient(clientData);
+    public ResponseEntity<?> create(@Valid @RequestBody ClientDTO dto) {
+        if (clientService.findByEmail(dto.email()).isPresent())
+            return ResponseEntity.status(HttpStatus.CONFLICT)
+                    .body("El correo ya existe");
+
+        Client saved = clientService.registerClient(
+                Client.builder()
+                        .email(dto.email())
+                        .name(dto.name())
+                        .phone(dto.phone())
+                        .build());
+
         return ResponseEntity.ok(saved);
     }
 

--- a/client-service/src/main/java/cl/kartingrm/client_service/dto/ClientDTO.java
+++ b/client-service/src/main/java/cl/kartingrm/client_service/dto/ClientDTO.java
@@ -1,0 +1,6 @@
+package cl.kartingrm.client_service.dto;
+
+public record ClientDTO(
+        @jakarta.validation.constraints.Email String email,
+        @jakarta.validation.constraints.NotBlank String name,
+        String phone) {}

--- a/client-service/src/main/java/cl/kartingrm/client_service/model/Client.java
+++ b/client-service/src/main/java/cl/kartingrm/client_service/model/Client.java
@@ -1,5 +1,6 @@
 package cl.kartingrm.client_service.model;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -8,6 +9,7 @@ import java.util.List;
 
 @Entity
 @Table(name = "clients")
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @Getter
 @Setter
 @NoArgsConstructor
@@ -26,6 +28,7 @@ public class Client {
 
     private String phone;
 
+    @Column(nullable = false, updatable = false)
     private LocalDateTime registeredAt;
 
     @OneToMany(mappedBy = "client", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/client-service/src/test/java/cl/kartingrm/client_service/ClientControllerTest.java
+++ b/client-service/src/test/java/cl/kartingrm/client_service/ClientControllerTest.java
@@ -41,6 +41,14 @@ class ClientControllerTest {
     }
 
     @Test
+    void create_client_missing_name_bad_request() throws Exception {
+        mvc.perform(post("/api/clients")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"email\":\"x@x.com\"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
     void get_visits_count() throws Exception {
         given(service.countVisitsThisMonth(eq("b@c.com"))).willReturn(3);
 

--- a/config-repo/client-service.properties
+++ b/config-repo/client-service.properties
@@ -7,6 +7,7 @@ eureka.client.service-url.defaultZone=http://discovery:8761/eureka/
 
 spring.flyway.baseline-on-migrate=true
 spring.jpa.hibernate.ddl-auto=validate
+spring.jpa.open-in-view=false
 
 #  solo la necesitas si ejecutas contra MySQL 8\u2002→ el Dialect lo autodetecta
 # spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 30
+      start_period: 40s
 
   discovery:
     build:
@@ -35,6 +36,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 30
+      start_period: 40s
 
   pricing-db:
     image: mysql:8.0.33
@@ -152,6 +154,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 30
+      start_period: 40s
 
   reservation:
     build:
@@ -182,6 +185,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 30
+      start_period: 40s
 
   client:
     build:
@@ -210,6 +214,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 30
+      start_period: 40s
 
   # microservicio sesiones
   session:
@@ -235,6 +240,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 30
+      start_period: 40s
 
   payment:
     build:
@@ -261,6 +267,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 30
+      start_period: 40s
 
   report:
     build:
@@ -287,6 +294,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 30
+      start_period: 40s
 
   gateway:
     build:
@@ -317,6 +325,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 30
+      start_period: 40s
 
   frontend:
     build: ./kartingrm-frontend

--- a/kartingrm-frontend/src/http-common.js
+++ b/kartingrm-frontend/src/http-common.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-const base = '';
+const base = import.meta.env.VITE_API_BASE_URL;
 
 const http = axios.create({
   baseURL: base,

--- a/kartingrm-frontend/src/pages/ClientsCrud.jsx
+++ b/kartingrm-frontend/src/pages/ClientsCrud.jsx
@@ -8,7 +8,7 @@ export default function ClientsCrud() {
   const [rows, setRows] = useState([])
   const [open, setOpen] = useState(false)
   const [edit, setEdit] = useState(null)
-  const [form, setForm] = useState({ fullName:'', email:'', phone:'', birthDate:''/*, adress:''*/ })
+  const [form, setForm] = useState({ name:'', email:'', phone:'', birthDate:''/*, adress:''*/ })
 
   /* ---------- carga inicial con AbortController ---------- */
   useEffect(() => {
@@ -35,14 +35,14 @@ export default function ClientsCrud() {
   const handleSave = async () => {
     try {
       if (edit) {
-        await clientService.update(edit.id, form)
+        await clientService.update(edit.id, { email: form.email, name: form.name, phone: form.phone })
       } else {
-        await clientService.create(form)
+        await clientService.create({ email: form.email, name: form.name, phone: form.phone })
       }
       await reload()
       setOpen(false)
       setEdit(null)
-      setForm({ fullName:'', email:'', phone:'', birthDate:'',/* adress:'' */})
+      setForm({ name:'', email:'', phone:'', birthDate:'',/* adress:'' */})
     } catch (e) {
       console.error(e)
     }
@@ -60,7 +60,7 @@ export default function ClientsCrud() {
           rows={rows}
           columns={[
             { field:'id',        headerName:'ID',        width:70 },
-            { field:'fullName',  headerName:'Nombre',    width:200 },
+            { field:'name',      headerName:'Nombre',    width:200 },
             { field:'email',     headerName:'Email',     width:200 },
             { field:'phone',     headerName:'Teléfono',  width:150 },
             { field:'birthDate', headerName:'Nacimiento',width:130 },
@@ -87,8 +87,8 @@ export default function ClientsCrud() {
       <Dialog open={open} onClose={() => setOpen(false)}>
         <Paper sx={{ p:3, width:400 }}>
           <Stack spacing={2}>
-            <TextField label="Nombre"     value={form.fullName}
-              onChange={e=>setForm({ ...form, fullName:e.target.value })}/>
+            <TextField label="Nombre"     value={form.name}
+              onChange={e=>setForm({ ...form, name:e.target.value })}/>
             <TextField label="Email"      value={form.email}
               onChange={e=>setForm({ ...form, email:e.target.value })}/>
             <TextField label="Teléfono"   value={form.phone}

--- a/pricing-service/src/main/java/cl/kartingrm/pricing_service/model/TariffConfig.java
+++ b/pricing-service/src/main/java/cl/kartingrm/pricing_service/model/TariffConfig.java
@@ -21,7 +21,7 @@ public class TariffConfig {
 
     /** WEEKDAY / WEEKEND / HOLIDAY */
     @Enumerated(EnumType.STRING)
-    @Column(name = "rate_type", length = 10, nullable = false)
+    @Column(name = "rate_type", length = 8, nullable = false)
     private RateType rateType;
 
     private int laps;      // == minutes (simplificación)


### PR DESCRIPTION
## Summary
- add frontend baseURL via VITE_API_BASE_URL
- send name and phone when creating or updating clients
- implement ClientDTO with validation and add ApiExceptionHandler
- enforce `registeredAt` immutability and clean JSON output
- reduce `TariffConfig.rate_type` column length
- set `spring.jpa.open-in-view=false` for client service
- extend start_period of health checks for Spring services
- add test for invalid client creation

## Testing
- `./mvnw -q -pl client-service test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6847c2b82190832c9ae23152b8cad50e