### PR TITLE
Fix tariffs naming and reservation mapper

### DIFF
--- a/config-repo/gateway-service.properties
+++ b/config-repo/gateway-service.properties
@@ -24,6 +24,7 @@ spring.cloud.gateway.routes[4].predicates[0]=Path=/api/tariffs/**
 spring.cloud.gateway.routes[5].id=payment-route
 spring.cloud.gateway.routes[5].uri=lb://PAYMENT-SERVICE
 spring.cloud.gateway.routes[5].predicates[0]=Path=/api/payments/**
+spring.cloud.gateway.routes[5].filters[0]=StripPrefix=1
 
 spring.cloud.gateway.routes[6].id=report-route
 spring.cloud.gateway.routes[6].uri=lb://REPORT-SERVICE

--- a/kartingrm-frontend/src/pages/ReservationsList.jsx
+++ b/kartingrm-frontend/src/pages/ReservationsList.jsx
@@ -30,8 +30,15 @@ export default function ReservationsList() {
     reservationService.list().then(r => setList(r.data))
 
   const cancel = id =>
-    reservationService.cancel(id).then(reload)
-      .catch(err => alert(err.response?.data?.message || err.message))
+    reservationService.cancel(id)
+      .then(reload)
+      .catch(err => {
+        if (err.response?.status === 409){
+          window.dispatchEvent(new CustomEvent('httpError',{
+            detail:'La reserva ya está pagada o cancelada.'
+          }))
+        }
+      })
 
   return (
     <Paper sx={{ p:2 }}>

--- a/kartingrm-frontend/src/pages/TariffsCrud.jsx
+++ b/kartingrm-frontend/src/pages/TariffsCrud.jsx
@@ -10,7 +10,7 @@ export default function TariffsCrud(){
   useEffect(()=>{ tariffSvc.list().then(setRows) },[])
 
   const processRowUpdate = async (newRow) => {
-    await tariffSvc.update(newRow.rateType, newRow)
+    await tariffSvc.update(newRow.rate, newRow)
     return newRow
   }
 
@@ -19,11 +19,11 @@ export default function TariffsCrud(){
       <DataGrid
         rows={rows}
         columns={[
-          {field:'rateType',     headerName:'Tarifa',   width:130, editable:false},
-          {field:'basePrice',    headerName:'Precio',   width:130, editable:true, type:'number'},
+          {field:'rate',     headerName:'Tarifa',   width:130, editable:false},
+          {field:'price',    headerName:'Precio',   width:130, editable:true, type:'number'},
           {field:'minutes',  headerName:'Minutos',  width:130, editable:true, type:'number'}
         ]}
-        getRowId={r=>r.rateType}
+        getRowId={r=>r.rate}
         processRowUpdate={processRowUpdate}
         experimentalFeatures={{ newEditingApi: true }}
         autoHeight

--- a/kartingrm-frontend/src/services/tariff.service.js
+++ b/kartingrm-frontend/src/services/tariff.service.js
@@ -2,7 +2,7 @@
 import http from '../http-common'
 
 const list   = cfg => http.get('/tariffs', cfg).then(r => r.data)
-const update = (rateType, payload, cfg={}) =>
-  http.put(`/tariffs/${rateType}`, payload, cfg).then(r => r.data)
+const update = (rate, payload, cfg={}) =>
+  http.put(`/tariffs/${rate}`, payload, cfg).then(r => r.data)
 
 export default { list, update }

--- a/pricing-service/src/main/java/cl/kartingrm/pricing_service/controller/TariffController.java
+++ b/pricing-service/src/main/java/cl/kartingrm/pricing_service/controller/TariffController.java
@@ -24,9 +24,9 @@ public class TariffController {
     public TariffConfig update(@PathVariable RateType rate,
                                @RequestBody TariffConfig body) {
 
-        TariffConfig cfg = repo.findByRateTypeAndLaps(rate, body.getLaps())
+        TariffConfig cfg = repo.findByRateAndMinutes(rate, body.getMinutes())
                 .orElseThrow(() -> new NoSuchElementException("tarifa no encontrada"));
-        cfg.setBasePrice(body.getBasePrice());
+        cfg.setPrice(body.getPrice());
         cfg.setMinutes(body.getMinutes());
         return repo.save(cfg);
     }

--- a/pricing-service/src/main/java/cl/kartingrm/pricing_service/model/TariffConfig.java
+++ b/pricing-service/src/main/java/cl/kartingrm/pricing_service/model/TariffConfig.java
@@ -7,7 +7,7 @@ import lombok.*;
 @Entity
 @Table(
         name = "tariff_config",
-        uniqueConstraints = @UniqueConstraint(columnNames = {"rate_type", "laps"})
+        uniqueConstraints = @UniqueConstraint(columnNames = {"rate_type", "minutes"})
 )
 @Getter
 @Setter
@@ -21,10 +21,12 @@ public class TariffConfig {
 
     /** WEEKDAY / WEEKEND / HOLIDAY */
     @Enumerated(EnumType.STRING)
-    @Column(name = "rate_type", length = 8, nullable = false)
-    private RateType rateType;
+    @Column(name = "rate_type", length = 10, nullable = false)
+    private RateType rate;
 
     private int laps;      // == minutes (simplificación)
     private int minutes;
-    private int basePrice; // CLP enteros
+
+    @Column(nullable = false)
+    private int price; // CLP enteros
 }

--- a/pricing-service/src/main/java/cl/kartingrm/pricing_service/repository/TariffConfigRepository.java
+++ b/pricing-service/src/main/java/cl/kartingrm/pricing_service/repository/TariffConfigRepository.java
@@ -9,5 +9,5 @@ import java.util.Optional;
 
 public interface TariffConfigRepository
         extends JpaRepository<TariffConfig,Long> {
-    Optional<TariffConfig> findByRateTypeAndLaps(RateType rateType, int laps);
+    Optional<TariffConfig> findByRateAndMinutes(RateType rate, int minutes);
 }

--- a/pricing-service/src/main/java/cl/kartingrm/pricing_service/service/PricingService.java
+++ b/pricing-service/src/main/java/cl/kartingrm/pricing_service/service/PricingService.java
@@ -30,7 +30,7 @@ public class PricingService {
 
         TariffConfig cfg = tariffService.forDate(dto.sessionDate(), dto.laps());
 
-        double base = cfg.getBasePrice();
+        double base = cfg.getPrice();
         double groupPct = disc.groupDiscount(dto.participants());
 
         int visits = web.get()

--- a/pricing-service/src/main/java/cl/kartingrm/pricing_service/service/TariffService.java
+++ b/pricing-service/src/main/java/cl/kartingrm/pricing_service/service/TariffService.java
@@ -14,14 +14,14 @@ public class TariffService {
     private final TariffConfigRepository repo;
     private final HolidayService holidays;
 
-    public TariffConfig forDate(LocalDate date, int laps) {
+    public TariffConfig forDate(LocalDate date, int minutes) {
         RateType type;
         if (holidays.isHoliday(date)) type = RateType.HOLIDAY;
         else if (date.getDayOfWeek().getValue() >= 6) type = RateType.WEEKEND;
         else type = RateType.WEEKDAY;
 
-        return repo.findByRateTypeAndLaps(type, laps)
+        return repo.findByRateAndMinutes(type, minutes)
                 .orElseThrow(() -> new IllegalArgumentException(
-                        "Tarifa no hallada para " + type + ", " + laps + " laps"));
+                        "Tarifa no hallada para " + type + ", " + minutes + " min"));
     }
 }

--- a/pricing-service/src/main/resources/db/migration/V1__tariff_schema.sql
+++ b/pricing-service/src/main/resources/db/migration/V1__tariff_schema.sql
@@ -3,6 +3,6 @@ CREATE TABLE tariff_config(
     rate_type VARCHAR(10) NOT NULL,
     laps INT NOT NULL,
     minutes INT NOT NULL,
-    base_price INT NOT NULL,
-    UNIQUE KEY uq_rate_laps(rate_type,laps)
+    price INT NOT NULL,
+    UNIQUE KEY uq_rate_minutes(rate_type,minutes)
 ) ENGINE=InnoDB;

--- a/pricing-service/src/main/resources/db/migration/V2__seed_tariffs.sql
+++ b/pricing-service/src/main/resources/db/migration/V2__seed_tariffs.sql
@@ -1,4 +1,4 @@
-INSERT INTO tariff_config(rate_type,laps,minutes,base_price)
+INSERT INTO tariff_config(rate_type,laps,minutes,price)
 VALUES
   ('WEEKDAY',10,10,15000),
   ('WEEKDAY',15,15,20000),
@@ -9,4 +9,4 @@ VALUES
   ('HOLIDAY',10,10,19000),
   ('HOLIDAY',15,15,26000),
   ('HOLIDAY',20,20,31000)
-ON DUPLICATE KEY UPDATE base_price = VALUES(base_price);
+ON DUPLICATE KEY UPDATE price = VALUES(price);

--- a/reservation-service/src/main/java/cl/kartingrm/reservation_service/controller/ReservationController.java
+++ b/reservation-service/src/main/java/cl/kartingrm/reservation_service/controller/ReservationController.java
@@ -3,6 +3,7 @@ package cl.kartingrm.reservation_service.controller;
 
 import cl.kartingrm.reservation_service.dto.*;
 import cl.kartingrm.reservation_service.service.ReservationService;
+import cl.kartingrm.reservation_service.mapper.ReservationMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.*;
 public class ReservationController {
 
     private final ReservationService service;
+    private final ReservationMapper mapper;
 
     @PostMapping
     public ReservationResponse create(@RequestBody CreateReservationRequest req) {
@@ -19,11 +21,11 @@ public class ReservationController {
     }
 
     @GetMapping
-    public java.util.List<?> list() { return service.all(); }
+    public java.util.List<ReservationResponse> list() { return service.all(); }
 
     @PatchMapping("/{id}/cancel")
     public ReservationResponse cancel(@PathVariable Long id) {
         var r = service.cancel(id);
-        return new ReservationResponse(r.getId(), r.getFinalPrice(), r.getStatus());
+        return mapper.toDto(r);
     }
 }

--- a/reservation-service/src/main/java/cl/kartingrm/reservation_service/dto/ClientDTO.java
+++ b/reservation-service/src/main/java/cl/kartingrm/reservation_service/dto/ClientDTO.java
@@ -1,0 +1,3 @@
+package cl.kartingrm.reservation_service.dto;
+
+public record ClientDTO(Long id, String fullName, String email, String phone) {}

--- a/reservation-service/src/main/java/cl/kartingrm/reservation_service/dto/ReservationResponse.java
+++ b/reservation-service/src/main/java/cl/kartingrm/reservation_service/dto/ReservationResponse.java
@@ -1,9 +1,17 @@
 package cl.kartingrm.reservation_service.dto;
 
+import cl.kartingrm.reservation_service.model.RateType;
 import cl.kartingrm.reservation_service.model.ReservationStatus;
 
 public record ReservationResponse(
         Long id,
-        int finalPrice,
+        String reservationCode,
+        ClientDTO client,
+        SessionDTO session,
+        Integer participants,
+        RateType rateType,
+        Double basePrice,
+        Double discountPercentage,
+        Double finalPrice,
         ReservationStatus status
 ) {}

--- a/reservation-service/src/main/java/cl/kartingrm/reservation_service/dto/SessionDTO.java
+++ b/reservation-service/src/main/java/cl/kartingrm/reservation_service/dto/SessionDTO.java
@@ -1,0 +1,6 @@
+package cl.kartingrm.reservation_service.dto;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record SessionDTO(Long id, LocalDate sessionDate, LocalTime startTime, LocalTime endTime) {}

--- a/reservation-service/src/main/java/cl/kartingrm/reservation_service/mapper/ReservationMapper.java
+++ b/reservation-service/src/main/java/cl/kartingrm/reservation_service/mapper/ReservationMapper.java
@@ -1,0 +1,23 @@
+package cl.kartingrm.reservation_service.mapper;
+
+import cl.kartingrm.reservation_service.dto.*;
+import cl.kartingrm.reservation_service.model.Reservation;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ReservationMapper {
+    public ReservationResponse toDto(Reservation entity) {
+        return new ReservationResponse(
+                entity.getId(),
+                null,
+                null,
+                null,
+                entity.getParticipants(),
+                null,
+                (double) entity.getBasePrice(),
+                (double) entity.getDiscountPercent(),
+                (double) entity.getFinalPrice(),
+                entity.getStatus()
+        );
+    }
+}

--- a/reservation-service/src/main/java/cl/kartingrm/reservation_service/model/RateType.java
+++ b/reservation-service/src/main/java/cl/kartingrm/reservation_service/model/RateType.java
@@ -1,0 +1,3 @@
+package cl.kartingrm.reservation_service.model;
+
+public enum RateType { WEEKDAY, WEEKEND, HOLIDAY }

--- a/reservation-service/src/main/java/cl/kartingrm/reservation_service/service/ReservationService.java
+++ b/reservation-service/src/main/java/cl/kartingrm/reservation_service/service/ReservationService.java
@@ -8,6 +8,7 @@ import cl.kartingrm.reservation_service.dto.*;
 import cl.kartingrm.reservation_service.model.Reservation;
 import cl.kartingrm.reservation_service.model.ReservationStatus;
 import cl.kartingrm.reservation_service.repository.ReservationRepository;
+import cl.kartingrm.reservation_service.mapper.ReservationMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -23,6 +24,7 @@ public class ReservationService {
     private final ReservationPersister persister;
     private final ReservationRepository repo;
     private final WebClient web;
+    private final ReservationMapper mapper;
 
     private static final String PRICING_URL = "lb://PRICING-SERVICE";
     private static final String CLIENT_URL = "lb://CLIENT-SERVICE";
@@ -45,11 +47,11 @@ public class ReservationService {
                 .retry(3)
                 .block();
 
-        return new ReservationResponse(saved.getId(), saved.getFinalPrice(), saved.getStatus());
+        return mapper.toDto(saved);
     }
 
-    public java.util.List<Reservation> all() {
-        return repo.findAll();
+    public java.util.List<ReservationResponse> all() {
+        return repo.findAll().stream().map(mapper::toDto).toList();
     }
 
     public Reservation cancel(Long id) {


### PR DESCRIPTION
## Summary
- rename tariff fields `rate` and `price`
- expose repository methods using minutes
- update tariff controller and services
- adjust flyway scripts
- extend reservation DTO and mapper
- update frontend to handle new names and errors
- add gateway StripPrefix for payments

## Testing
- `mvn test` *(fails: Non-resolvable parent POM)*
- `npm test` *(no output)*

------
https://chatgpt.com/codex/tasks/task_e_6847d2236f2c832cb197cabd47709e55