### PR TITLE
Add laps info for reservations

### DIFF
--- a/kartingrm-frontend/src/helpers.js
+++ b/kartingrm-frontend/src/helpers.js
@@ -6,11 +6,15 @@
 export function buildTariffMaps(tariffs = []) {
   const priceMap = {}
   const durMap   = {}
+  const lapsMap  = {}
+
   tariffs.forEach(t => {
     priceMap[t.rate] = t.price
     durMap[t.rate]   = t.minutes
+    lapsMap[t.rate]  = t.laps ?? t.minutes
   })
-  return { priceMap, durMap }
+
+  return { priceMap, durMap, lapsMap }
 }
 
 /**

--- a/kartingrm-frontend/src/pages/ReservationForm.jsx
+++ b/kartingrm-frontend/src/pages/ReservationForm.jsx
@@ -81,7 +81,7 @@ export default function ReservationForm(){
   const rateType    = watch('rateType')
 
   /* ---------- mapas precio / duración ---------- */
-  const { priceMap, durMap } = useMemo(
+  const { priceMap, durMap, lapsMap } = useMemo(
     () => buildTariffMaps(tariffs),
     [tariffs]
   )
@@ -133,10 +133,12 @@ export default function ReservationForm(){
   },[startTime, rateType, sessionDate, durMap, setValue])
 
   /* ---------- envío ---------- */
-  const onSubmit = data =>
-    reservationService.create(data)
+  const onSubmit = data => {
+    const payload = { ...data, laps: lapsMap[data.rateType] }
+    reservationService.create(payload)
       .then(res => navigate(`/payments/${res.id}`, { replace:true }))
       .catch(e  => alert(e.response?.data?.message || e.message))
+  }
 
   /* ---------- resumen ---------- */
   const summary = useMemo(() => {


### PR DESCRIPTION
## Summary
- extend `buildTariffMaps` to return a `lapsMap`
- include laps when submitting reservations

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network issues)*

------
https://chatgpt.com/codex/tasks/task_e_6847e10a59b8832ca6a48701043ceb8f