### PR TITLE
Add tariffs admin page and auto duration calc

### DIFF
--- a/kartingrm-frontend/src/pages/ReservationForm.jsx
+++ b/kartingrm-frontend/src/pages/ReservationForm.jsx
@@ -125,12 +125,21 @@ export default function ReservationForm(){
 
   /* 6) calcular hora fin automática */
   useEffect(()=>{
-    if (!startTime || !rateType || !sessionDate) return
-    const mins = durMap[rateType] ?? 0
-    const end  = dayjs(`${sessionDate} ${startTime}`)
-                   .add(mins,'minute').format('HH:mm')
-    setValue('endTime', end, { shouldValidate:true, shouldDirty:true })
-  },[startTime, rateType, sessionDate, durMap, setValue])
+    if(!startTime || !rateType) return
+    if(!sessionDate) return
+    const fetchMinutes = async () => {
+      try{
+        const data = await tariffSvc.list()
+        const row = data.find(r => r.rate === rateType)
+        if(row){
+          const newEnd = dayjs(`${sessionDate} ${startTime}`)
+                           .add(row.minutes,'minute').format('HH:mm')
+          setValue('endTime', newEnd, { shouldValidate:true, shouldDirty:true })
+        }
+      }catch(e){ /* silencio */ }
+    }
+    fetchMinutes()
+  },[startTime, rateType, sessionDate, setValue])
 
   /* ---------- envío ---------- */
   const onSubmit = data => {

--- a/kartingrm-frontend/src/pages/TariffsCrud.jsx
+++ b/kartingrm-frontend/src/pages/TariffsCrud.jsx
@@ -1,36 +1,76 @@
 // src/pages/TariffsCrud.jsx
 import { useEffect, useState } from 'react'
-import { DataGrid } from '@mui/x-data-grid'
-import { Paper, Button } from '@mui/material'
-import tariffSvc from '../services/tariff.service'
+import {
+  Paper, Typography, Table, TableHead, TableBody, TableRow, TableCell,
+  TextField, IconButton, CircularProgress, Stack
+} from '@mui/material'
+import SaveIcon   from '@mui/icons-material/Save'
+import tariffSvc  from '../services/tariff.service'
 
-export default function TariffsCrud(){
-  const [rows,setRows]=useState([])
+export default function TariffsCrud () {
+  const [rows, setRows]    = useState([])
+  const [saving, setSaving]= useState(false)
 
-  useEffect(()=>{ tariffSvc.list().then(setRows) },[])
+  const load = () => tariffSvc.list().then(setRows)
 
-  const processRowUpdate = async (newRow) => {
-    await tariffSvc.update(newRow.rate, newRow)
-    return newRow
+  useEffect(load, [])
+
+  const handleChange = (idx, field, value) => {
+    setRows(r => {
+      const clone = [...r]
+      clone[idx] = { ...clone[idx], [field]: value }
+      return clone
+    })
+  }
+
+  const save = async (row) => {
+    setSaving(true)
+    try {
+      await tariffSvc.update(row.rate, { price:+row.price, minutes:+row.minutes })
+      alert('Tarifa actualizada')
+      load()
+    } catch (e) {
+      alert(e.response?.data?.message ?? e.message)
+    } finally {
+      setSaving(false)
+    }
   }
 
   return (
-    <Paper sx={{p:2}}>
-      <DataGrid
-        rows={rows}
-        columns={[
-          {field:'rate',     headerName:'Tarifa',   width:130, editable:false},
-          {field:'price',    headerName:'Precio',   width:130, editable:true, type:'number'},
-          {field:'minutes',  headerName:'Minutos',  width:130, editable:true, type:'number'}
-        ]}
-        getRowId={r=>r.rate}
-        processRowUpdate={processRowUpdate}
-        experimentalFeatures={{ newEditingApi: true }}
-        autoHeight
-      />
-      <Button sx={{mt:2}} onClick={()=>tariffSvc.list().then(setRows)}>
-        Recargar
-      </Button>
+    <Paper sx={{ p:3 }}>
+      <Stack direction="row" justifyContent="space-between" mb={2}>
+        <Typography variant="h6">Tarifas / Precios</Typography>
+        {saving && <CircularProgress size={20}/>}
+      </Stack>
+
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            {['Tarifa','Precio (CL$)','Min.',''].map(h=>
+              <TableCell key={h}>{h}</TableCell>)}
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {rows.map((r,i)=>(
+            <TableRow key={r.rate}>
+              <TableCell>{r.rate}</TableCell>
+              <TableCell>
+                <TextField variant="standard" type="number" size="small"
+                  value={r.price} onChange={e=>handleChange(i,'price',e.target.value)}/>
+              </TableCell>
+              <TableCell>
+                <TextField variant="standard" type="number" size="small"
+                  value={r.minutes} onChange={e=>handleChange(i,'minutes',e.target.value)}/>
+              </TableCell>
+              <TableCell>
+                <IconButton onClick={()=>save(r)} disabled={saving}>
+                  <SaveIcon/>
+                </IconButton>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
     </Paper>
   )
 }


### PR DESCRIPTION
## Summary
- simplify Tariffs CRUD page with editable table
- recalc end time using tariff data on ReservationForm

## Testing
- `npm run lint` *(fails: cannot resolve `@eslint/js`)*
- `./mvnw -q test` *(fails: could not resolve Spring parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6869b3412324832c8712ebcbe6600c84